### PR TITLE
chore: apply v4 e2e fixes in ffi diff report to prior proposals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
 
+      # WORKAROUND: build the V4 diff CLI from the aave-helpers submodule.
+      # Needed before the aave-helpers-js package is updated
+      - name: Build V4 diff CLI from submodule
+        working-directory: lib/aave-helpers
+        run: npx -y pnpm install
+
       # we simply use foundry zk for all jobs in this repo
       - name: Run Foundry setup
         uses: bgd-labs/github-workflows/.github/actions/foundry-setup@main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/aave-helpers"]
 	path = lib/aave-helpers
-	url = git@github.com:aave/aave-helpers.git
+	url = git@github.com:aave-dao/aave-helpers.git
 	branch = test/v4-e2e
 [submodule "lib/aave-umbrella"]
 	path = lib/aave-umbrella

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,8 +1,8 @@
 {
   "lib/aave-helpers": {
     "branch": {
-      "name": "main",
-      "rev": "9350321d2ce927d6e07e5486e1d3abf5a55cd707"
+      "name": "test/v4-e2e",
+      "rev": "18185fdc413a85e3a921d0cc5c978151edb7681a"
     }
   },
   "lib/aave-umbrella": {

--- a/src/20260409_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260409.t.sol
+++ b/src/20260409_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260409.t.sol
@@ -75,7 +75,26 @@ contract AaveV4Ethereum_IncreaseCaps_20260409_Test is ProtocolV4TestBase {
     vm.writeJson(rawDiff, afterPath, '$.raw');
     vm.writeJson(logsJson, afterPath, '$.logs');
 
-    diffV4Snapshots(reportName, snapshotBefore, snapshotAfter);
+    // WORKAROUND: @aave-dao/aave-helpers-js@^1.0.1 does not have
+    // `diff-v4-snapshots` published yet
+    {
+      string memory diffOutPath = string.concat(
+        './diffs/',
+        reportName,
+        '_before_',
+        reportName,
+        '_after.md'
+      );
+      string[] memory inputs = new string[](7);
+      inputs[0] = 'node';
+      inputs[1] = 'lib/aave-helpers/packages/aave-helpers-js/dist/cli.mjs';
+      inputs[2] = 'diff-v4-snapshots';
+      inputs[3] = string.concat('./reports/', beforeName, '.json');
+      inputs[4] = string.concat('./reports/', afterName, '.json');
+      inputs[5] = '-o';
+      inputs[6] = diffOutPath;
+      vm.ffi(inputs);
+    }
   }
 
   // ================================================================

--- a/src/20260415_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260415.t.sol
+++ b/src/20260415_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260415.t.sol
@@ -70,7 +70,26 @@ contract AaveV4Ethereum_IncreaseCaps_20260415_Test is ProtocolV4TestBase {
     vm.writeJson(rawDiff, afterPath, '$.raw');
     vm.writeJson(logsJson, afterPath, '$.logs');
 
-    diffV4Snapshots(reportName, snapshotBefore, snapshotAfter);
+    // WORKAROUND: @aave-dao/aave-helpers-js@^1.0.1 does not have
+    // `diff-v4-snapshots` published yet
+    {
+      string memory diffOutPath = string.concat(
+        './diffs/',
+        reportName,
+        '_before_',
+        reportName,
+        '_after.md'
+      );
+      string[] memory inputs = new string[](7);
+      inputs[0] = 'node';
+      inputs[1] = 'lib/aave-helpers/packages/aave-helpers-js/dist/cli.mjs';
+      inputs[2] = 'diff-v4-snapshots';
+      inputs[3] = string.concat('./reports/', beforeName, '.json');
+      inputs[4] = string.concat('./reports/', afterName, '.json');
+      inputs[5] = '-o';
+      inputs[6] = diffOutPath;
+      vm.ffi(inputs);
+    }
   }
 
   // ================================================================

--- a/src/20260504_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260504.t.sol
+++ b/src/20260504_AaveV4Ethereum_IncreaseCaps/AaveV4Ethereum_IncreaseCaps_20260504.t.sol
@@ -69,7 +69,26 @@ contract AaveV4Ethereum_IncreaseCaps_20260504_Test is ProtocolV4TestBase {
     vm.writeJson(rawDiff, afterPath, '$.raw');
     vm.writeJson(logsJson, afterPath, '$.logs');
 
-    diffV4Snapshots(reportName, snapshotBefore, snapshotAfter);
+    // WORKAROUND: @aave-dao/aave-helpers-js@^1.0.1 does not have
+    // `diff-v4-snapshots` published yet
+    {
+      string memory diffOutPath = string.concat(
+        './diffs/',
+        reportName,
+        '_before_',
+        reportName,
+        '_after.md'
+      );
+      string[] memory inputs = new string[](7);
+      inputs[0] = 'node';
+      inputs[1] = 'lib/aave-helpers/packages/aave-helpers-js/dist/cli.mjs';
+      inputs[2] = 'diff-v4-snapshots';
+      inputs[3] = string.concat('./reports/', beforeName, '.json');
+      inputs[4] = string.concat('./reports/', afterName, '.json');
+      inputs[5] = '-o';
+      inputs[6] = diffOutPath;
+      vm.ffi(inputs);
+    }
   }
 
   // ================================================================


### PR DESCRIPTION
- upstream v4 e2e tests updated the diff reports to be js-based instead of solidity based, in line with v3 style
- fix this in prior proposals, including workaround while the v4 e2e tests are not yet merged into main, and js package is not yet published 