### PR TITLE
feat: aave v4 cap increase round 12

### DIFF
--- a/diffs/AaveV4Avalanche_IncreaseCaps_20260803_before_AaveV4Avalanche_IncreaseCaps_20260803_after.md
+++ b/diffs/AaveV4Avalanche_IncreaseCaps_20260803_before_AaveV4Avalanche_IncreaseCaps_20260803_after.md
@@ -18,8 +18,8 @@
 
 | description | value before | value after |
 | --- | --- | --- |
-| addCap | 300,000 (3e5) EURC | 1,500,000 (1.5e6) EURC |
-| drawCap | 400,000 (4e5) EURC | 1,500,000 (1.5e6) EURC |
+| addCap | 300,000 (3e5) EURC | 1,600,000 (1.6e6) EURC |
+| drawCap | 400,000 (4e5) EURC | 1,600,000 (1.6e6) EURC |
 
 ## Event logs
 
@@ -27,7 +27,7 @@
 
 | index | event |
 | --- | --- |
-| 0 | UpdateSpokeConfig(assetId: 5, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1500000, drawCap: 1500000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 0 | UpdateSpokeConfig(assetId: 5, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1600000, drawCap: 1600000, riskPremiumThreshold: 0, active: true, halted: false}) |
 | 1 | UpdateSpokeConfig(assetId: 2, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1000000, drawCap: 950000, riskPremiumThreshold: 0, active: true, halted: false}) |
 | 2 | UpdateSpokeConfig(assetId: 3, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1000000, drawCap: 950000, riskPremiumThreshold: 0, active: true, halted: false}) |
 
@@ -45,7 +45,7 @@
 | --- | --- | --- |
 | 0x91cc139c3ecf77fff04c15491bcef0b4b96d035fe67e78778222cc1c13cf88ff | 0x0000000100000000000557300000061a800000000000000000000003eaffe643 | 0x0000000100000000000e7ef000000f42400000000000000000000003eaffe643 |
 | 0xb6910ad7f9cb00bfac48ebaffad7429821f847eb31ea6142257707b03d7c6fdc | 0x0000000100000000000557300000061a800000000000000000000046dc58b1fb | 0x0000000100000000000e7ef000000f42400000000000000000000046dc58b1fb |
-| 0xdbb38d951ecc9fc8aa9742c14ccb40601a7cc2768ae153b5f7a0a5a7bf79f4e5 | 0x000000010000000000061a8000000493e000000000000000000000000f041547 | 0x00000001000000000016e360000016e36000000000000000000000000f041547 |
+| 0xdbb38d951ecc9fc8aa9742c14ccb40601a7cc2768ae153b5f7a0a5a7bf79f4e5 | 0x000000010000000000061a8000000493e000000000000000000000000f041547 | 0x000000010000000000186a000000186a0000000000000000000000000f041547 |
 
 
 ## Raw diff
@@ -76,11 +76,11 @@
     "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e_5_0x6a37776B5E026dBdF043b4F933c323C84DD1B514": {
       "addCap": {
         "from": 300000,
-        "to": 1500000
+        "to": 1600000
       },
       "drawCap": {
         "from": 400000,
-        "to": 1500000
+        "to": 1600000
       }
     }
   }

--- a/diffs/AaveV4Avalanche_IncreaseCaps_20260803_before_AaveV4Avalanche_IncreaseCaps_20260803_after.md
+++ b/diffs/AaveV4Avalanche_IncreaseCaps_20260803_before_AaveV4Avalanche_IncreaseCaps_20260803_after.md
@@ -1,0 +1,88 @@
+## Hub Spoke Config Changes
+
+### USDC (assetId: 2) on Hub [0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e](https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e) / Spoke [0x6a37776B5E026dBdF043b4F933c323C84DD1B514](https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 400,000 (4e5) USDC | 1,000,000 (1e6) USDC |
+| drawCap | 350,000 (3.5e5) USDC | 950,000 (9.5e5) USDC |
+
+### USDt (assetId: 3) on Hub [0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e](https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e) / Spoke [0x6a37776B5E026dBdF043b4F933c323C84DD1B514](https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 400,000 (4e5) USDt | 1,000,000 (1e6) USDt |
+| drawCap | 350,000 (3.5e5) USDt | 950,000 (9.5e5) USDt |
+
+### EURC (assetId: 5) on Hub [0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e](https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e) / Spoke [0x6a37776B5E026dBdF043b4F933c323C84DD1B514](https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 300,000 (3e5) EURC | 1,500,000 (1.5e6) EURC |
+| drawCap | 400,000 (4e5) EURC | 1,500,000 (1.5e6) EURC |
+
+## Event logs
+
+#### 0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e (AaveV4Avalanche.ALL_HUBS[0], AaveV4Avalanche.HUBS.CORE_HUB)
+
+| index | event |
+| --- | --- |
+| 0 | UpdateSpokeConfig(assetId: 5, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1500000, drawCap: 1500000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 1 | UpdateSpokeConfig(assetId: 2, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1000000, drawCap: 950000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 2 | UpdateSpokeConfig(assetId: 3, spoke: 0x6a37776B5E026dBdF043b4F933c323C84DD1B514, config: {addCap: 1000000, drawCap: 950000, riskPremiumThreshold: 0, active: true, halted: false}) |
+
+#### 0xb619fA61e795D47f517702e63ce50292370561F1
+
+| index | event |
+| --- | --- |
+| 3 | ExecutedAction(target: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f, value: 0, signature: execute(), data: 0x, executionTime: 1785747477, withDelegatecall: true, resultData: 0x) |
+
+## Raw storage changes
+
+### 0xd07369fae4a5bb13c9ce446b052c7867b1abdf6e (AaveV4Avalanche.ALL_HUBS[0], AaveV4Avalanche.HUBS.CORE_HUB)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x91cc139c3ecf77fff04c15491bcef0b4b96d035fe67e78778222cc1c13cf88ff | 0x0000000100000000000557300000061a800000000000000000000003eaffe643 | 0x0000000100000000000e7ef000000f42400000000000000000000003eaffe643 |
+| 0xb6910ad7f9cb00bfac48ebaffad7429821f847eb31ea6142257707b03d7c6fdc | 0x0000000100000000000557300000061a800000000000000000000046dc58b1fb | 0x0000000100000000000e7ef000000f42400000000000000000000046dc58b1fb |
+| 0xdbb38d951ecc9fc8aa9742c14ccb40601a7cc2768ae153b5f7a0a5a7bf79f4e5 | 0x000000010000000000061a8000000493e000000000000000000000000f041547 | 0x00000001000000000016e360000016e36000000000000000000000000f041547 |
+
+
+## Raw diff
+
+```json
+{
+  "spokeConfigs": {
+    "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e_2_0x6a37776B5E026dBdF043b4F933c323C84DD1B514": {
+      "addCap": {
+        "from": 400000,
+        "to": 1000000
+      },
+      "drawCap": {
+        "from": 350000,
+        "to": 950000
+      }
+    },
+    "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e_3_0x6a37776B5E026dBdF043b4F933c323C84DD1B514": {
+      "addCap": {
+        "from": 400000,
+        "to": 1000000
+      },
+      "drawCap": {
+        "from": 350000,
+        "to": 950000
+      }
+    },
+    "0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e_5_0x6a37776B5E026dBdF043b4F933c323C84DD1B514": {
+      "addCap": {
+        "from": 300000,
+        "to": 1500000
+      },
+      "drawCap": {
+        "from": 400000,
+        "to": 1500000
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
+++ b/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
@@ -1,0 +1,386 @@
+## Spoke Reserve Changes
+
+### USDG ([0xe343167631d89B6Ffc58B88d6b7fB0228795491D](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D)) on Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) [reserveId: 2]
+
+**NEW RESERVE**
+
+| description | value |
+| --- | --- |
+| symbol | USDG |
+| underlying | [0xe343167631d89B6Ffc58B88d6b7fB0228795491D](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D) |
+| hub | [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) |
+| assetId | 8 |
+| decimals | 6 |
+| collateralRisk | 0.00 % [0] |
+| paused | :x: |
+| frozen | :x: |
+| borrowable | :white_check_mark: |
+| receiveSharesEnabled | :white_check_mark: |
+| dynamicConfigKey | 0 |
+| collateralFactor | 0.00 % [0] |
+| maxLiquidationBonus | 0.00 % [10000] |
+| liquidationFee | 0.00 % [0] |
+| oracleAddress | [0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A](https://etherscan.io/address/0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A) |
+| priceSource | [0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4](https://etherscan.io/address/0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
+| oraclePrice | 100,007,000 (1.00007e8) |
+
+**dynamicConfigs**
+
+| key | field | before | after |
+| --- | --- | --- | --- |
+| key 0 | collateralFactor | *missing* | 0.00 % [0] |
+| key 0 | maxLiquidationBonus | *missing* | 0.00 % [10000] |
+| key 0 | liquidationFee | *missing* | 0.00 % [0] |
+
+
+## Hub Spoke Config Changes
+
+### sUSDe (assetId: 2) on Hub [0x06002e9c4412CB7814a791eA3666D905871E536A](https://etherscan.io/address/0x06002e9c4412CB7814a791eA3666D905871E536A) / Spoke [0xba1B3D55D249692b669A164024A838309B7508AF](https://etherscan.io/address/0xba1B3D55D249692b669A164024A838309B7508AF)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 8,000,000 (8e6) sUSDe | 10,000,000 (1e7) sUSDe |
+
+### USDC (assetId: 4) on Hub [0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931](https://etherscan.io/address/0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931) / Spoke [0x973a023A77420ba610f06b3858aD991Df6d85A08](https://etherscan.io/address/0x973a023A77420ba610f06b3858aD991Df6d85A08)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 12,590,000 (1.259e7) USDC | 20,000,000 (2e7) USDC |
+| drawCap | 14,590,000 (1.459e7) USDC | 20,000,000 (2e7) USDC |
+
+### WETH (assetId: 0) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xbF10BDfE177dE0336aFD7fcCF80A904E15386219](https://etherscan.io/address/0xbF10BDfE177dE0336aFD7fcCF80A904E15386219)
+
+| description | value before | value after |
+| --- | --- | --- |
+| drawCap | 20,000 (2e4) WETH | 30,000 (3e4) WETH |
+
+### EURC (assetId: 10) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718](https://etherscan.io/address/0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 112,500 (1.125e5) EURC | 1,000,000 (1e6) EURC |
+
+### wstETH (assetId: 1) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x94e7A5dCbE816e498b89aB752661904E2F56c485](https://etherscan.io/address/0x94e7A5dCbE816e498b89aB752661904E2F56c485)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 10,000 (1e4) wstETH | 15,000 (1.5e4) wstETH |
+
+### USDT (assetId: 4) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73](https://etherscan.io/address/0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 312,500 (3.125e5) USDT | 1,000,000 (1e6) USDT |
+
+### USDT (assetId: 4) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x65407b940966954b23dfA3caA5C0702bB42984DC](https://etherscan.io/address/0x65407b940966954b23dfA3caA5C0702bB42984DC)
+
+| description | value before | value after |
+| --- | --- | --- |
+| drawCap | 2,000,000 (2e6) USDT | 2,500,000 (2.5e6) USDT |
+
+### USDT (assetId: 4) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x94e7A5dCbE816e498b89aB752661904E2F56c485](https://etherscan.io/address/0x94e7A5dCbE816e498b89aB752661904E2F56c485)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 20,000,000 (2e7) USDT | 24,000,000 (2.4e7) USDT |
+
+### USDT (assetId: 4) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x973a023A77420ba610f06b3858aD991Df6d85A08](https://etherscan.io/address/0x973a023A77420ba610f06b3858aD991Df6d85A08)
+
+| description | value before | value after |
+| --- | --- | --- |
+| drawCap | 2,500,000 (2.5e6) USDT | 4,000,000 (4e6) USDT |
+
+### USDC (assetId: 5) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x531E90a2376902DE8915789Fcc1075e3B0c153E7](https://etherscan.io/address/0x531E90a2376902DE8915789Fcc1075e3B0c153E7)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 312,500 (3.125e5) USDC | 1,000,000 (1e6) USDC |
+
+### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x94e7A5dCbE816e498b89aB752661904E2F56c485](https://etherscan.io/address/0x94e7A5dCbE816e498b89aB752661904E2F56c485)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 65,000,000 (6.5e7) USDG | 75,000,000 (7.5e7) USDG |
+| drawCap | 35,000,000 (3.5e7) USDG | 45,000,000 (4.5e7) USDG |
+
+### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xAC2435E3C25e8246870D33ce0a26988A46d5DB68](https://etherscan.io/address/0xAC2435E3C25e8246870D33ce0a26988A46d5DB68)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 125,000 (1.25e5) USDG | 1,000,000 (1e6) USDG |
+
+### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1](https://etherscan.io/address/0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1)
+
+| description | value before | value after |
+| --- | --- | --- |
+| drawCap | 500,000 (5e5) USDG | 1,000,000 (1e6) USDG |
+
+### frxUSD (assetId: 9) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xba1B3D55D249692b669A164024A838309B7508AF](https://etherscan.io/address/0xba1B3D55D249692b669A164024A838309B7508AF)
+
+| description | value before | value after |
+| --- | --- | --- |
+| drawCap | 500,000 (5e5) frxUSD | 1,000,000 (1e6) frxUSD |
+
+### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989)
+
+**NEW SPOKE**
+
+| description | value |
+| --- | --- |
+| assetSymbol | USDG |
+| addCap | 0 USDG |
+| drawCap | 5,000,000 (5e6) USDG |
+| riskPremiumThreshold | 0.00 % [0] |
+| active | :white_check_mark: |
+| halted | :x: |
+
+## Event logs
+
+#### 0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9 (AaveV4Ethereum.ALL_HUBS[0], AaveV4Ethereum.HUBS.CORE_HUB)
+
+| index | event |
+| --- | --- |
+| 0 | AddSpoke(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989) |
+| 1 | UpdateSpokeConfig(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989, config: {addCap: 0, drawCap: 5000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 2 | UpdateSpokeConfig(assetId: 0, spoke: 0xbF10BDfE177dE0336aFD7fcCF80A904E15386219, config: {addCap: 0, drawCap: 30000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 3 | UpdateSpokeConfig(assetId: 8, spoke: 0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 4 | UpdateSpokeConfig(assetId: 4, spoke: 0x65407b940966954b23dfA3caA5C0702bB42984DC, config: {addCap: 0, drawCap: 2500000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 5 | UpdateSpokeConfig(assetId: 8, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 75000000, drawCap: 45000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 6 | UpdateSpokeConfig(assetId: 4, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 24000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 7 | UpdateSpokeConfig(assetId: 1, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 15000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 8 | UpdateSpokeConfig(assetId: 10, spoke: 0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 9 | UpdateSpokeConfig(assetId: 5, spoke: 0x531E90a2376902DE8915789Fcc1075e3B0c153E7, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 10 | UpdateSpokeConfig(assetId: 8, spoke: 0xAC2435E3C25e8246870D33ce0a26988A46d5DB68, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 11 | UpdateSpokeConfig(assetId: 4, spoke: 0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 12 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 0, drawCap: 4000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 13 | UpdateSpokeConfig(assetId: 9, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+
+#### 0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931 (AaveV4Ethereum.ALL_HUBS[2], AaveV4Ethereum.HUBS.PRIME_HUB)
+
+| index | event |
+| --- | --- |
+| 14 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 20000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+
+#### 0x06002e9c4412CB7814a791eA3666D905871E536A (AaveV4Ethereum.ALL_HUBS[1], AaveV4Ethereum.HUBS.PLUS_HUB)
+
+| index | event |
+| --- | --- |
+| 15 | UpdateSpokeConfig(assetId: 2, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 10000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+
+#### 0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A
+
+| index | event |
+| --- | --- |
+| 16 | UpdateReserveSource(reserveId: 2, source: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
+
+#### 0x774b9655413c34809c1f1b16b654465A89EBE989
+
+| index | event |
+| --- | --- |
+| 17 | UpdateReservePriceSource(reserveId: 2, priceSource: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
+| 18 | AddReserve(reserveId: 2, assetId: 8, hub: 0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) |
+| 19 | UpdateReserveConfig(reserveId: 2, config: {collateralRisk: 0, paused: false, frozen: false, borrowable: true, receiveSharesEnabled: true}) |
+| 20 | AddDynamicReserveConfig(reserveId: 2, dynamicConfigKey: 0, config: {collateralFactor: 0, maxLiquidationBonus: 10000, liquidationFee: 0}) |
+
+#### 0x14339e2178A954d5FB839D5Ff31644fE0F25F517
+
+| index | event |
+| --- | --- |
+| 21 | ExecutedAction(target: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f, value: 0, signature: execute(), data: 0x, executionTime: 1785747467, withDelegatecall: true, resultData: 0x) |
+
+## Raw storage changes
+
+### 0x06002e9c4412cb7814a791ea3666d905871e536a (AaveV4Ethereum.ALL_HUBS[1], AaveV4Ethereum.HUBS.PLUS_HUB)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x0ebc18c00c44b55501f91a7275feb1ba6c99323cd6a1c803e7cd8db27bf307bf | 0x00000001000000000000000000007a120000000000033af9607bd56fdc4dcd49 | 0x000000010000000000000000000098968000000000033af9607bd56fdc4dcd49 |
+
+### 0x47a7cc7fd47aced15087a8b6e0acfddcd63c811a
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0xd9d16d34ffb15ba3a3d852f0d403e2ce1d691fb54de27ac87cd2f993f3ec330f | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000000000000000083d20deedcd4ac1313496c8cbcaad0fa298c0ce4 |
+
+### 0x774b9655413c34809c1f1b16b654465a89ebe989
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 | 0x0000000000000000000000000000000000000000000000000000000000000003 |
+| 0x23a8b3930d40243c6050962392c5f42a8d68219c31a95256ad251969f8898d7d | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000027100000 |
+| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28c | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000e343167631d89b6ffc58b88d6b7fb0228795491d |
+| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28d | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000c000000060008cca852bc40e560adc3b1cc58ca5b55638ce826c9 |
+| 0x8739f8fcebae0416d97aa58c1cd3020cda853ca9af0a15fd808c2ae49e399a66 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 |
+
+### 0x943827dca022d0f354a8a8c332da1e5eb9f9f931 (AaveV4Ethereum.ALL_HUBS[2], AaveV4Ethereum.HUBS.PRIME_HUB)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x198c88e1eeee20438ef0ba84b1ffa6730bc7f34cd573e1d080cf9289acdb1da7 | 0x000000010000000000dea0300000c01bb0000000000000000000027cec26f9ed | 0x000000010000000001312d000001312d00000000000000000000027cec26f9ed |
+
+### 0xcca852bc40e560adc3b1cc58ca5b55638ce826c9 (AaveV4Ethereum.ALL_HUBS[0], AaveV4Ethereum.HUBS.CORE_HUB)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x157068e44105b2f21e33fe77807472332893be1673868c8e3dd8f4044fdc286f | 0x00000001000000000007a1200000000000000000000000000000000000000000 | 0x0000000100000000000f42400000000000000000000000000000000000000000 |
+| 0x198c88e1eeee20438ef0ba84b1ffa6730bc7f34cd573e1d080cf9289acdb1da7 | 0x0000000100000000002625a00000000000000000000000000000000000000000 | 0x0000000100000000003d09000000000000000000000000000000000000000000 |
+| 0x29c61b1026dbe3182385cb38d755156a11e01368a21f37d60ee651ca75301f47 | 0x000000010000000000004e200000000000000000000000000000000000000000 | 0x0000000100000000000075300000000000000000000000000000000000000000 |
+| 0x3331d28bd5592baf31227b930bff5d57dde2a3c71870ab6055d4c6f043889547 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000100000000004c4b400000000000000000000000000000000000000000 |
+| 0x3ecc32a16dd883599cd1f3781d816cd0dfa0bbefd4999b54c60caa6f4647aacf | 0x0000000100000000001e84800000000000000000000000000000000000000000 | 0x0000000100000000002625a00000000000000000000000000000000000000000 |
+| 0x71a369ff12b15f756a3a343762bb215a56bd5d233d347237bdc42da29f554437 | 0x000000010000000000000000000004c4b40000000000000000000000cb5c28e6 | 0x00000001000000000000000000000f42400000000000000000000000cb5c28e6 |
+| 0x84259f7f7b6591cf2e5e2cf666f1a1bd46709ac9580f2cf5c756725264424ecc | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000774b9655413c34809c1f1b16b654465a89ebe989 |
+| 0x85aaa47b6dc46495bb8824fad4583769726fea36efd831a35556690b830a8fbe | 0x0000000000000000000000000000000000000000000000000000000000000006 | 0x0000000000000000000000000000000000000000000000000000000000000007 |
+| 0x99bb93d28ad7ef1ec651ad977009e24c2b90e9d14aa0fcfcb792ba8875c509b6 | 0x000000010000000000000000000000271000000000000185a81bdc947ec5c58d | 0x0000000100000000000000000000003a9800000000000185a81bdc947ec5c58d |
+| 0xa6da33bb70f6ba09e6983df5deee35eb8b4546f79269a1b9a48fa0594ed9afea | 0x000000010000000000000000000001b77400000000000000000000081b8464e5 | 0x00000001000000000000000000000f424000000000000000000000081b8464e5 |
+| 0xb49c968e87e71235e482fbf881b9053d0de668fc6988dfe1106d381761e4c6b5 | 0x000000010000000001312d000001312d000000000000000000000c3b851f655b | 0x000000010000000001312d0000016e36000000000000000000000c3b851f655b |
+| 0xca3f065b3a636b0d1dd454dd81d8181910403c4a862b8b8c44b0cf79f5e55b1a | 0x00000001000000000007a1200000000000000000000000000000000000000000 | 0x0000000100000000000f42400000000000000000000000000000000000000000 |
+| 0xd5c50ad9fa0bc7e0f131a0bf3396f964018b014ac5b779d15db07c3a1aadf361 | 0x000000010000000000000000000004c4b40000000000000000000007a30106e1 | 0x00000001000000000000000000000f42400000000000000000000007a30106e1 |
+| 0xe8439494412af67e512cc5ad87ff66084b58e3315644860df87a52b5ee1fd27a | 0x000000010000000002160ec00003dfd240000000000000000000368316fe7f0a | 0x000000010000000002aea54000047868c0000000000000000000368316fe7f0a |
+| 0xef1094e3183e63f5b1cd208d481e7cceb8170355bcd7c68fd8f62fc65316a356 | 0x000000010000000000000000000001e848000000000000000000001cfc77f425 | 0x00000001000000000000000000000f4240000000000000000000001cfc77f425 |
+| 0xffcee35a8ae524a466416346a95511a439c4407eaf59acc3577aa9693495b545 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000007 |
+
+
+## Raw diff
+
+```json
+{
+  "spokeConfigs": {
+    "0x06002e9c4412CB7814a791eA3666D905871E536A_2_0xba1B3D55D249692b669A164024A838309B7508AF": {
+      "addCap": {
+        "from": 8000000,
+        "to": 10000000
+      }
+    },
+    "0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931_4_0x973a023A77420ba610f06b3858aD991Df6d85A08": {
+      "addCap": {
+        "from": 12590000,
+        "to": 20000000
+      },
+      "drawCap": {
+        "from": 14590000,
+        "to": 20000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_0_0xbF10BDfE177dE0336aFD7fcCF80A904E15386219": {
+      "drawCap": {
+        "from": 20000,
+        "to": 30000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_10_0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718": {
+      "addCap": {
+        "from": 112500,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_1_0x94e7A5dCbE816e498b89aB752661904E2F56c485": {
+      "addCap": {
+        "from": 10000,
+        "to": 15000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_4_0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73": {
+      "addCap": {
+        "from": 312500,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_4_0x65407b940966954b23dfA3caA5C0702bB42984DC": {
+      "drawCap": {
+        "from": 2000000,
+        "to": 2500000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_4_0x94e7A5dCbE816e498b89aB752661904E2F56c485": {
+      "addCap": {
+        "from": 20000000,
+        "to": 24000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_4_0x973a023A77420ba610f06b3858aD991Df6d85A08": {
+      "drawCap": {
+        "from": 2500000,
+        "to": 4000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_5_0x531E90a2376902DE8915789Fcc1075e3B0c153E7": {
+      "addCap": {
+        "from": 312500,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0x94e7A5dCbE816e498b89aB752661904E2F56c485": {
+      "addCap": {
+        "from": 65000000,
+        "to": 75000000
+      },
+      "drawCap": {
+        "from": 35000000,
+        "to": 45000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0xAC2435E3C25e8246870D33ce0a26988A46d5DB68": {
+      "addCap": {
+        "from": 125000,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1": {
+      "drawCap": {
+        "from": 500000,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_9_0xba1B3D55D249692b669A164024A838309B7508AF": {
+      "drawCap": {
+        "from": 500000,
+        "to": 1000000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0x774b9655413c34809c1f1b16b654465A89EBE989": {
+      "from": null,
+      "to": {
+        "active": true,
+        "addCap": 0,
+        "assetSymbol": "USDG",
+        "drawCap": 5000000,
+        "halted": false,
+        "riskPremiumThreshold": 0
+      }
+    }
+  },
+  "spokeReserves": {
+    "0x774b9655413c34809c1f1b16b654465A89EBE989": {
+      "2": {
+        "from": null,
+        "to": {
+          "assetId": 8,
+          "borrowable": true,
+          "collateralFactor": 0,
+          "collateralRisk": 0,
+          "decimals": 6,
+          "dynamicConfigKey": 0,
+          "dynamicConfigs": {
+            "0": {
+              "collateralFactor": 0,
+              "liquidationFee": 0,
+              "maxLiquidationBonus": 10000
+            }
+          },
+          "frozen": false,
+          "hub": "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9",
+          "liquidationFee": 0,
+          "maxLiquidationBonus": 10000,
+          "oracleAddress": "0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A",
+          "oraclePrice": "100007000",
+          "paused": false,
+          "priceSource": "0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4",
+          "receiveSharesEnabled": true,
+          "symbol": "USDG",
+          "underlying": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
+++ b/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
@@ -1,6 +1,39 @@
 ## Spoke Reserve Changes
 
-### USDG ([0xe343167631d89B6Ffc58B88d6b7fB0228795491D](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D)) on Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) [reserveId: 2]
+### USDC ([0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48)) on Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) [reserveId: 2]
+
+**NEW RESERVE**
+
+| description | value |
+| --- | --- |
+| symbol | USDC |
+| underlying | [0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) |
+| hub | [0x62d63197660c080236193CA60b70E49A08E90368](https://etherscan.io/address/0x62d63197660c080236193CA60b70E49A08E90368) |
+| assetId | 1 |
+| decimals | 6 |
+| collateralRisk | 0.00 % [0] |
+| paused | :x: |
+| frozen | :x: |
+| borrowable | :white_check_mark: |
+| receiveSharesEnabled | :white_check_mark: |
+| dynamicConfigKey | 0 |
+| collateralFactor | 0.00 % [0] |
+| maxLiquidationBonus | 0.00 % [10000] |
+| liquidationFee | 0.00 % [0] |
+| oracleAddress | [0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A](https://etherscan.io/address/0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A) |
+| priceSource | [0x3f73F03aa83B2A48ed27E964eD0fDb590332095B](https://etherscan.io/address/0x3f73F03aa83B2A48ed27E964eD0fDb590332095B) |
+| oraclePrice | 99,977,230 (9.997723e7) |
+
+**dynamicConfigs**
+
+| key | field | before | after |
+| --- | --- | --- | --- |
+| key 0 | collateralFactor | *missing* | 0.00 % [0] |
+| key 0 | maxLiquidationBonus | *missing* | 0.00 % [10000] |
+| key 0 | liquidationFee | *missing* | 0.00 % [0] |
+
+
+### USDG ([0xe343167631d89B6Ffc58B88d6b7fB0228795491D](https://etherscan.io/address/0xe343167631d89B6Ffc58B88d6b7fB0228795491D)) on Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) [reserveId: 3]
 
 **NEW RESERVE**
 
@@ -35,12 +68,6 @@
 
 ## Hub Spoke Config Changes
 
-### sUSDe (assetId: 2) on Hub [0x06002e9c4412CB7814a791eA3666D905871E536A](https://etherscan.io/address/0x06002e9c4412CB7814a791eA3666D905871E536A) / Spoke [0xba1B3D55D249692b669A164024A838309B7508AF](https://etherscan.io/address/0xba1B3D55D249692b669A164024A838309B7508AF)
-
-| description | value before | value after |
-| --- | --- | --- |
-| addCap | 8,000,000 (8e6) sUSDe | 10,000,000 (1e7) sUSDe |
-
 ### USDC (assetId: 4) on Hub [0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931](https://etherscan.io/address/0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931) / Spoke [0x973a023A77420ba610f06b3858aD991Df6d85A08](https://etherscan.io/address/0x973a023A77420ba610f06b3858aD991Df6d85A08)
 
 | description | value before | value after |
@@ -65,6 +92,12 @@
 | description | value before | value after |
 | --- | --- | --- |
 | addCap | 10,000 (1e4) wstETH | 15,000 (1.5e4) wstETH |
+
+### weETH (assetId: 2) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xbF10BDfE177dE0336aFD7fcCF80A904E15386219](https://etherscan.io/address/0xbF10BDfE177dE0336aFD7fcCF80A904E15386219)
+
+| description | value before | value after |
+| --- | --- | --- |
+| addCap | 28,000 (2.8e4) weETH | 37,000 (3.7e4) weETH |
 
 ### USDT (assetId: 4) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73](https://etherscan.io/address/0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73)
 
@@ -96,13 +129,6 @@
 | --- | --- | --- |
 | addCap | 312,500 (3.125e5) USDC | 1,000,000 (1e6) USDC |
 
-### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x94e7A5dCbE816e498b89aB752661904E2F56c485](https://etherscan.io/address/0x94e7A5dCbE816e498b89aB752661904E2F56c485)
-
-| description | value before | value after |
-| --- | --- | --- |
-| addCap | 65,000,000 (6.5e7) USDG | 75,000,000 (7.5e7) USDG |
-| drawCap | 35,000,000 (3.5e7) USDG | 45,000,000 (4.5e7) USDG |
-
 ### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0xAC2435E3C25e8246870D33ce0a26988A46d5DB68](https://etherscan.io/address/0xAC2435E3C25e8246870D33ce0a26988A46d5DB68)
 
 | description | value before | value after |
@@ -121,6 +147,19 @@
 | --- | --- | --- |
 | drawCap | 500,000 (5e5) frxUSD | 1,000,000 (1e6) frxUSD |
 
+### USDC (assetId: 1) on Hub [0x62d63197660c080236193CA60b70E49A08E90368](https://etherscan.io/address/0x62d63197660c080236193CA60b70E49A08E90368) / Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989)
+
+**NEW SPOKE**
+
+| description | value |
+| --- | --- |
+| assetSymbol | USDC |
+| addCap | 1,000,000 (1e6) USDC |
+| drawCap | 1,000,000 (1e6) USDC |
+| riskPremiumThreshold | 0.00 % [0] |
+| active | :white_check_mark: |
+| halted | :x: |
+
 ### USDG (assetId: 8) on Hub [0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9](https://etherscan.io/address/0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) / Spoke [0x774b9655413c34809c1f1b16b654465A89EBE989](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989)
 
 **NEW SPOKE**
@@ -136,81 +175,95 @@
 
 ## Event logs
 
+#### 0x62d63197660c080236193CA60b70E49A08E90368 (AaveV4Ethereum.ALL_HUBS[3], AaveV4Ethereum.HUBS.PAXOS_HUB)
+
+| index | event |
+| --- | --- |
+| 0 | AddSpoke(assetId: 1, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989) |
+| 1 | UpdateSpokeConfig(assetId: 1, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989, config: {addCap: 1000000, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+
 #### 0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9 (AaveV4Ethereum.ALL_HUBS[0], AaveV4Ethereum.HUBS.CORE_HUB)
 
 | index | event |
 | --- | --- |
-| 0 | AddSpoke(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989) |
-| 1 | UpdateSpokeConfig(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989, config: {addCap: 0, drawCap: 5000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 2 | UpdateSpokeConfig(assetId: 0, spoke: 0xbF10BDfE177dE0336aFD7fcCF80A904E15386219, config: {addCap: 0, drawCap: 30000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 3 | UpdateSpokeConfig(assetId: 8, spoke: 0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 4 | UpdateSpokeConfig(assetId: 4, spoke: 0x65407b940966954b23dfA3caA5C0702bB42984DC, config: {addCap: 0, drawCap: 2500000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 5 | UpdateSpokeConfig(assetId: 8, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 75000000, drawCap: 45000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 6 | UpdateSpokeConfig(assetId: 4, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 24000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 7 | UpdateSpokeConfig(assetId: 1, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 15000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 8 | UpdateSpokeConfig(assetId: 10, spoke: 0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 9 | UpdateSpokeConfig(assetId: 5, spoke: 0x531E90a2376902DE8915789Fcc1075e3B0c153E7, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 10 | UpdateSpokeConfig(assetId: 8, spoke: 0xAC2435E3C25e8246870D33ce0a26988A46d5DB68, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 11 | UpdateSpokeConfig(assetId: 4, spoke: 0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 12 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 0, drawCap: 4000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 13 | UpdateSpokeConfig(assetId: 9, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 2 | AddSpoke(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989) |
+| 3 | UpdateSpokeConfig(assetId: 8, spoke: 0x774b9655413c34809c1f1b16b654465A89EBE989, config: {addCap: 0, drawCap: 5000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 4 | UpdateSpokeConfig(assetId: 0, spoke: 0xbF10BDfE177dE0336aFD7fcCF80A904E15386219, config: {addCap: 0, drawCap: 30000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 5 | UpdateSpokeConfig(assetId: 2, spoke: 0xbF10BDfE177dE0336aFD7fcCF80A904E15386219, config: {addCap: 37000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 6 | UpdateSpokeConfig(assetId: 8, spoke: 0xD8B93635b8C6d0fF98CbE90b5988E3F2d1Cd9da1, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 7 | UpdateSpokeConfig(assetId: 4, spoke: 0x65407b940966954b23dfA3caA5C0702bB42984DC, config: {addCap: 0, drawCap: 2500000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 8 | UpdateSpokeConfig(assetId: 4, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 24000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 9 | UpdateSpokeConfig(assetId: 1, spoke: 0x94e7A5dCbE816e498b89aB752661904E2F56c485, config: {addCap: 15000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 10 | UpdateSpokeConfig(assetId: 10, spoke: 0x6D9e2Cdd61CaF69af99b275704B6e272C41c6718, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 11 | UpdateSpokeConfig(assetId: 5, spoke: 0x531E90a2376902DE8915789Fcc1075e3B0c153E7, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 12 | UpdateSpokeConfig(assetId: 8, spoke: 0xAC2435E3C25e8246870D33ce0a26988A46d5DB68, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 13 | UpdateSpokeConfig(assetId: 4, spoke: 0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 14 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 0, drawCap: 4000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 15 | UpdateSpokeConfig(assetId: 9, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
 
 #### 0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931 (AaveV4Ethereum.ALL_HUBS[2], AaveV4Ethereum.HUBS.PRIME_HUB)
 
 | index | event |
 | --- | --- |
-| 14 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 20000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-
-#### 0x06002e9c4412CB7814a791eA3666D905871E536A (AaveV4Ethereum.ALL_HUBS[1], AaveV4Ethereum.HUBS.PLUS_HUB)
-
-| index | event |
-| --- | --- |
-| 15 | UpdateSpokeConfig(assetId: 2, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 10000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 16 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 20000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
 
 #### 0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A
 
 | index | event |
 | --- | --- |
-| 16 | UpdateReserveSource(reserveId: 2, source: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
+| 17 | UpdateReserveSource(reserveId: 2, source: 0x3f73F03aa83B2A48ed27E964eD0fDb590332095B) |
+| 22 | UpdateReserveSource(reserveId: 3, source: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
 
 #### 0x774b9655413c34809c1f1b16b654465A89EBE989
 
 | index | event |
 | --- | --- |
-| 17 | UpdateReservePriceSource(reserveId: 2, priceSource: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
-| 18 | AddReserve(reserveId: 2, assetId: 8, hub: 0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) |
-| 19 | UpdateReserveConfig(reserveId: 2, config: {collateralRisk: 0, paused: false, frozen: false, borrowable: true, receiveSharesEnabled: true}) |
-| 20 | AddDynamicReserveConfig(reserveId: 2, dynamicConfigKey: 0, config: {collateralFactor: 0, maxLiquidationBonus: 10000, liquidationFee: 0}) |
+| 18 | UpdateReservePriceSource(reserveId: 2, priceSource: 0x3f73F03aa83B2A48ed27E964eD0fDb590332095B) |
+| 19 | AddReserve(reserveId: 2, assetId: 1, hub: 0x62d63197660c080236193CA60b70E49A08E90368) |
+| 20 | UpdateReserveConfig(reserveId: 2, config: {collateralRisk: 0, paused: false, frozen: false, borrowable: true, receiveSharesEnabled: true}) |
+| 21 | AddDynamicReserveConfig(reserveId: 2, dynamicConfigKey: 0, config: {collateralFactor: 0, maxLiquidationBonus: 10000, liquidationFee: 0}) |
+| 23 | UpdateReservePriceSource(reserveId: 3, priceSource: 0x83D20dEEdcd4aC1313496c8CBcAad0fa298c0CE4) |
+| 24 | AddReserve(reserveId: 3, assetId: 8, hub: 0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9) |
+| 25 | UpdateReserveConfig(reserveId: 3, config: {collateralRisk: 0, paused: false, frozen: false, borrowable: true, receiveSharesEnabled: true}) |
+| 26 | AddDynamicReserveConfig(reserveId: 3, dynamicConfigKey: 0, config: {collateralFactor: 0, maxLiquidationBonus: 10000, liquidationFee: 0}) |
 
 #### 0x14339e2178A954d5FB839D5Ff31644fE0F25F517
 
 | index | event |
 | --- | --- |
-| 21 | ExecutedAction(target: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f, value: 0, signature: execute(), data: 0x, executionTime: 1785747467, withDelegatecall: true, resultData: 0x) |
+| 27 | ExecutedAction(target: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f, value: 0, signature: execute(), data: 0x, executionTime: 1785747467, withDelegatecall: true, resultData: 0x) |
 
 ## Raw storage changes
-
-### 0x06002e9c4412cb7814a791ea3666d905871e536a (AaveV4Ethereum.ALL_HUBS[1], AaveV4Ethereum.HUBS.PLUS_HUB)
-
-| slot | previous value | new value |
-| --- | --- | --- |
-| 0x0ebc18c00c44b55501f91a7275feb1ba6c99323cd6a1c803e7cd8db27bf307bf | 0x00000001000000000000000000007a120000000000033af9607bd56fdc4dcd49 | 0x000000010000000000000000000098968000000000033af9607bd56fdc4dcd49 |
 
 ### 0x47a7cc7fd47aced15087a8b6e0acfddcd63c811a
 
 | slot | previous value | new value |
 | --- | --- | --- |
-| 0xd9d16d34ffb15ba3a3d852f0d403e2ce1d691fb54de27ac87cd2f993f3ec330f | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000000000000000083d20deedcd4ac1313496c8cbcaad0fa298c0ce4 |
+| 0x7dfe757ecd65cbd7922a9c0161e935dd7fdbcc0e999689c7d31633896b1fc60b | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000000000000000083d20deedcd4ac1313496c8cbcaad0fa298c0ce4 |
+| 0xd9d16d34ffb15ba3a3d852f0d403e2ce1d691fb54de27ac87cd2f993f3ec330f | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000003f73f03aa83b2a48ed27e964ed0fdb590332095b |
+
+### 0x62d63197660c080236193ca60b70e49a08e90368 (AaveV4Ethereum.ALL_HUBS[3], AaveV4Ethereum.HUBS.PAXOS_HUB)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0x2c644dcf44e265ba93879b2da89e1b16ab48fc5eb8e31bc16b0612d6da8463f5 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000774b9655413c34809c1f1b16b654465a89ebe989 |
+| 0x41880475aad8e8296be4b9058b4dfb00f479cc503f8ae3a902d25413a20748e9 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000005 |
+| 0x6ea0d85889aecb2d2328f8fe8e3bd4400b35917269acd48a581b478cab608380 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000100000000000f424000000f4240000000000000000000000000000000 |
+| 0xa15bc60c955c405d20d9149c709e2460f1c2d9a497496a7f46004d1772c3054c | 0x0000000000000000000000000000000000000000000000000000000000000004 | 0x0000000000000000000000000000000000000000000000000000000000000005 |
 
 ### 0x774b9655413c34809c1f1b16b654465a89ebe989
 
 | slot | previous value | new value |
 | --- | --- | --- |
-| 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 | 0x0000000000000000000000000000000000000000000000000000000000000003 |
+| 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 | 0x0000000000000000000000000000000000000000000000000000000000000004 |
 | 0x23a8b3930d40243c6050962392c5f42a8d68219c31a95256ad251969f8898d7d | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000027100000 |
-| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28c | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000e343167631d89b6ffc58b88d6b7fb0228795491d |
-| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28d | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000c000000060008cca852bc40e560adc3b1cc58ca5b55638ce826c9 |
-| 0x8739f8fcebae0416d97aa58c1cd3020cda853ca9af0a15fd808c2ae49e399a66 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 |
+| 0x28b425f61cad6d11aeb5a0203d47cee5c848ac803463a42255b3f6bb79a2e3a2 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000027100000 |
+| 0x3a7920452422ef48e47ab6d357a518cadf6507e9f771e2bdffaed84ff517def6 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000002 |
+| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28c | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 |
+| 0x679795a0195a1b76cdebb7c51d74e058aee92919b8c3389af86ef24535e8a28d | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000c00000006000162d63197660c080236193ca60b70e49a08e90368 |
+| 0x8739f8fcebae0416d97aa58c1cd3020cda853ca9af0a15fd808c2ae49e399a66 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000003 |
+| 0x88601476d11616a71c5be67555bd1dff4b1cbf21533d2669b768b61518cfe1c3 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x000000000000000000000000e343167631d89b6ffc58b88d6b7fb0228795491d |
+| 0x88601476d11616a71c5be67555bd1dff4b1cbf21533d2669b768b61518cfe1c4 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x00000000000c000000060008cca852bc40e560adc3b1cc58ca5b55638ce826c9 |
 
 ### 0x943827dca022d0f354a8a8c332da1e5eb9f9f931 (AaveV4Ethereum.ALL_HUBS[2], AaveV4Ethereum.HUBS.PRIME_HUB)
 
@@ -224,6 +277,7 @@
 | --- | --- | --- |
 | 0x157068e44105b2f21e33fe77807472332893be1673868c8e3dd8f4044fdc286f | 0x00000001000000000007a1200000000000000000000000000000000000000000 | 0x0000000100000000000f42400000000000000000000000000000000000000000 |
 | 0x198c88e1eeee20438ef0ba84b1ffa6730bc7f34cd573e1d080cf9289acdb1da7 | 0x0000000100000000002625a00000000000000000000000000000000000000000 | 0x0000000100000000003d09000000000000000000000000000000000000000000 |
+| 0x24e7ddce26f075881cccb771a7cf25c70ac4edbf2500c7be345fdb9a00eb25e1 | 0x0000000100000000000000000000006d600000000000035786a78d29e1cf0faa | 0x00000001000000000000000000000090880000000000035786a78d29e1cf0faa |
 | 0x29c61b1026dbe3182385cb38d755156a11e01368a21f37d60ee651ca75301f47 | 0x000000010000000000004e200000000000000000000000000000000000000000 | 0x0000000100000000000075300000000000000000000000000000000000000000 |
 | 0x3331d28bd5592baf31227b930bff5d57dde2a3c71870ab6055d4c6f043889547 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000100000000004c4b400000000000000000000000000000000000000000 |
 | 0x3ecc32a16dd883599cd1f3781d816cd0dfa0bbefd4999b54c60caa6f4647aacf | 0x0000000100000000001e84800000000000000000000000000000000000000000 | 0x0000000100000000002625a00000000000000000000000000000000000000000 |
@@ -235,7 +289,6 @@
 | 0xb49c968e87e71235e482fbf881b9053d0de668fc6988dfe1106d381761e4c6b5 | 0x000000010000000001312d000001312d000000000000000000000c3b851f655b | 0x000000010000000001312d0000016e36000000000000000000000c3b851f655b |
 | 0xca3f065b3a636b0d1dd454dd81d8181910403c4a862b8b8c44b0cf79f5e55b1a | 0x00000001000000000007a1200000000000000000000000000000000000000000 | 0x0000000100000000000f42400000000000000000000000000000000000000000 |
 | 0xd5c50ad9fa0bc7e0f131a0bf3396f964018b014ac5b779d15db07c3a1aadf361 | 0x000000010000000000000000000004c4b40000000000000000000007a30106e1 | 0x00000001000000000000000000000f42400000000000000000000007a30106e1 |
-| 0xe8439494412af67e512cc5ad87ff66084b58e3315644860df87a52b5ee1fd27a | 0x000000010000000002160ec00003dfd240000000000000000000368316fe7f0a | 0x000000010000000002aea54000047868c0000000000000000000368316fe7f0a |
 | 0xef1094e3183e63f5b1cd208d481e7cceb8170355bcd7c68fd8f62fc65316a356 | 0x000000010000000000000000000001e848000000000000000000001cfc77f425 | 0x00000001000000000000000000000f4240000000000000000000001cfc77f425 |
 | 0xffcee35a8ae524a466416346a95511a439c4407eaf59acc3577aa9693495b545 | 0x0000000000000000000000000000000000000000000000000000000000000000 | 0x0000000000000000000000000000000000000000000000000000000000000007 |
 
@@ -245,12 +298,6 @@
 ```json
 {
   "spokeConfigs": {
-    "0x06002e9c4412CB7814a791eA3666D905871E536A_2_0xba1B3D55D249692b669A164024A838309B7508AF": {
-      "addCap": {
-        "from": 8000000,
-        "to": 10000000
-      }
-    },
     "0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931_4_0x973a023A77420ba610f06b3858aD991Df6d85A08": {
       "addCap": {
         "from": 12590000,
@@ -277,6 +324,12 @@
       "addCap": {
         "from": 10000,
         "to": 15000
+      }
+    },
+    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_2_0xbF10BDfE177dE0336aFD7fcCF80A904E15386219": {
+      "addCap": {
+        "from": 28000,
+        "to": 37000
       }
     },
     "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_4_0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73": {
@@ -309,16 +362,6 @@
         "to": 1000000
       }
     },
-    "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0x94e7A5dCbE816e498b89aB752661904E2F56c485": {
-      "addCap": {
-        "from": 65000000,
-        "to": 75000000
-      },
-      "drawCap": {
-        "from": 35000000,
-        "to": 45000000
-      }
-    },
     "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0xAC2435E3C25e8246870D33ce0a26988A46d5DB68": {
       "addCap": {
         "from": 125000,
@@ -337,6 +380,17 @@
         "to": 1000000
       }
     },
+    "0x62d63197660c080236193CA60b70E49A08E90368_1_0x774b9655413c34809c1f1b16b654465A89EBE989": {
+      "from": null,
+      "to": {
+        "active": true,
+        "addCap": 1000000,
+        "assetSymbol": "USDC",
+        "drawCap": 1000000,
+        "halted": false,
+        "riskPremiumThreshold": 0
+      }
+    },
     "0xCca852Bc40e560adC3b1Cc58CA5b55638ce826c9_8_0x774b9655413c34809c1f1b16b654465A89EBE989": {
       "from": null,
       "to": {
@@ -352,6 +406,35 @@
   "spokeReserves": {
     "0x774b9655413c34809c1f1b16b654465A89EBE989": {
       "2": {
+        "from": null,
+        "to": {
+          "assetId": 1,
+          "borrowable": true,
+          "collateralFactor": 0,
+          "collateralRisk": 0,
+          "decimals": 6,
+          "dynamicConfigKey": 0,
+          "dynamicConfigs": {
+            "0": {
+              "collateralFactor": 0,
+              "liquidationFee": 0,
+              "maxLiquidationBonus": 10000
+            }
+          },
+          "frozen": false,
+          "hub": "0x62d63197660c080236193CA60b70E49A08E90368",
+          "liquidationFee": 0,
+          "maxLiquidationBonus": 10000,
+          "oracleAddress": "0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A",
+          "oraclePrice": "99977230",
+          "paused": false,
+          "priceSource": "0x3f73F03aa83B2A48ed27E964eD0fDb590332095B",
+          "receiveSharesEnabled": true,
+          "symbol": "USDC",
+          "underlying": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        }
+      },
+      "3": {
         "from": null,
         "to": {
           "assetId": 8,

--- a/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
+++ b/diffs/AaveV4Ethereum_IncreaseCaps_20260803_before_AaveV4Ethereum_IncreaseCaps_20260803_after.md
@@ -198,14 +198,14 @@
 | 11 | UpdateSpokeConfig(assetId: 5, spoke: 0x531E90a2376902DE8915789Fcc1075e3B0c153E7, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
 | 12 | UpdateSpokeConfig(assetId: 8, spoke: 0xAC2435E3C25e8246870D33ce0a26988A46d5DB68, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
 | 13 | UpdateSpokeConfig(assetId: 4, spoke: 0x5eC44a70F309854fe04d495cFE1B5dA63DD1cc73, config: {addCap: 1000000, drawCap: 0, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 14 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 0, drawCap: 4000000, riskPremiumThreshold: 0, active: true, halted: false}) |
-| 15 | UpdateSpokeConfig(assetId: 9, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 15 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 0, drawCap: 4000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 16 | UpdateSpokeConfig(assetId: 9, spoke: 0xba1B3D55D249692b669A164024A838309B7508AF, config: {addCap: 0, drawCap: 1000000, riskPremiumThreshold: 0, active: true, halted: false}) |
 
 #### 0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931 (AaveV4Ethereum.ALL_HUBS[2], AaveV4Ethereum.HUBS.PRIME_HUB)
 
 | index | event |
 | --- | --- |
-| 16 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 20000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
+| 14 | UpdateSpokeConfig(assetId: 4, spoke: 0x973a023A77420ba610f06b3858aD991Df6d85A08, config: {addCap: 20000000, drawCap: 20000000, riskPremiumThreshold: 0, active: true, halted: false}) |
 
 #### 0x47a7cC7Fd47aCed15087a8b6e0ACFddCD63C811A
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4AvalancheRound12.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4AvalancheRound12.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IAaveV4ConfigEngine} from 'aave-v4/config-engine/interfaces/IAaveV4ConfigEngine.sol';
+import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
+
+library AaveV4AvalancheRound12 {
+  // https://snowscan.xyz/address/0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c
+  IAaveV4ConfigEngine internal constant CONFIG_ENGINE =
+    IAaveV4ConfigEngine(0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c);
+  // https://snowscan.xyz/address/0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33
+  IHubConfigurator internal constant HUB_CONFIGURATOR =
+    IHubConfigurator(0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33);
+  // https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e
+  IHub internal constant CORE_HUB = IHub(0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e);
+  // https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514
+  ISpoke internal constant FOREX_SPOKE = ISpoke(0x6a37776B5E026dBdF043b4F933c323C84DD1B514);
+
+  // https://snowscan.xyz/address/0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD
+  address internal constant EURC = 0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD;
+  // https://snowscan.xyz/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
+  address internal constant USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+  // https://snowscan.xyz/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7
+  address internal constant USDt = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
@@ -28,7 +28,7 @@ library AaveV4AvalancheRound12 {
 /**
  * @title Increase add and draw caps on Avalanche
  * @author Llama Risk (implemented by Aave Labs)
- * - Discussion: https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c
+ * - Discussion: https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40
  * - To be executed by the Aave Security Council
  */
 contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
@@ -47,7 +47,7 @@ contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
     uint256 i = 0;
 
     //                             hub                                  spoke                                    asset                        addCap     drawCap
-    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.EURC, 1_500_000, 1_500_000);
+    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.EURC, 1_600_000, 1_600_000);
     updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDC, 1_000_000, 950_000);
     updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDt, 1_000_000, 950_000);
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
@@ -5,7 +5,7 @@ import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Pa
 import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
 import {ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
 
-import {AaveV4AvalancheRound12} from './AaveV4AvalancheRound12.sol';
+import {LocalAaveV4Avalanche} from './LocalV4AddressBook.sol';
 
 /**
  * @title Increase add and draw caps on Avalanche
@@ -14,7 +14,7 @@ import {AaveV4AvalancheRound12} from './AaveV4AvalancheRound12.sol';
  * - To be executed by the Aave Security Council
  */
 contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
-  constructor() AaveV4Payload(AaveV4AvalancheRound12.CONFIG_ENGINE) {}
+  constructor() AaveV4Payload(LocalAaveV4Avalanche.CONFIG_ENGINE) {}
 
   // prettier-ignore
   function hubSpokeConfigUpdates()
@@ -23,15 +23,18 @@ contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
     override
     returns (IAaveV4ConfigEngine.SpokeConfigUpdate[] memory)
   {
+    IHub CORE = LocalAaveV4Avalanche.CORE_HUB;
+    ISpoke FOREX = LocalAaveV4Avalanche.FOREX_SPOKE;
+
     IAaveV4ConfigEngine.SpokeConfigUpdate[]
       memory updates = new IAaveV4ConfigEngine.SpokeConfigUpdate[](3);
 
     uint256 i = 0;
 
-    //                             hub                                  spoke                                    asset                        addCap     drawCap
-    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.EURC, 1_600_000, 1_600_000);
-    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDC, 1_000_000, 950_000);
-    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDt, 1_000_000, 950_000);
+    //                             hub   spoke    asset                             addCap     drawCap
+    updates[i++] = _capUpdate(CORE, FOREX, LocalAaveV4Avalanche.EURC, 1_600_000, 1_600_000);
+    updates[i++] = _capUpdate(CORE, FOREX, LocalAaveV4Avalanche.USDC, 1_000_000, 950_000);
+    updates[i++] = _capUpdate(CORE, FOREX, LocalAaveV4Avalanche.USDt, 1_000_000, 950_000);
 
     require(i == updates.length, 'Invalid number of updates');
     return updates;
@@ -46,7 +49,7 @@ contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
   ) internal pure returns (IAaveV4ConfigEngine.SpokeConfigUpdate memory) {
     return
       IAaveV4ConfigEngine.SpokeConfigUpdate({
-        hubConfigurator: AaveV4AvalancheRound12.HUB_CONFIGURATOR,
+        hubConfigurator: LocalAaveV4Avalanche.HUB_CONFIGURATOR,
         hub: address(hub),
         underlying: underlying,
         spoke: address(spoke),

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Payload.sol';
+import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
+import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
+
+library AaveV4AvalancheRound12 {
+  // https://snowscan.xyz/address/0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c
+  IAaveV4ConfigEngine internal constant CONFIG_ENGINE =
+    IAaveV4ConfigEngine(0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c);
+  // https://snowscan.xyz/address/0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33
+  IHubConfigurator internal constant HUB_CONFIGURATOR =
+    IHubConfigurator(0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33);
+  // https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e
+  IHub internal constant CORE_HUB = IHub(0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e);
+  // https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514
+  ISpoke internal constant FOREX_SPOKE = ISpoke(0x6a37776B5E026dBdF043b4F933c323C84DD1B514);
+
+  // https://snowscan.xyz/address/0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD
+  address internal constant EURC = 0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD;
+  // https://snowscan.xyz/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
+  address internal constant USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+  // https://snowscan.xyz/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7
+  address internal constant USDt = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
+}
+
+/**
+ * @title Increase add and draw caps on Avalanche
+ * @author Llama Risk (implemented by Aave Labs)
+ * - Discussion: https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c
+ * - To be executed by the Aave Security Council
+ */
+contract AaveV4Avalanche_IncreaseCaps_20260803 is AaveV4Payload {
+  constructor() AaveV4Payload(AaveV4AvalancheRound12.CONFIG_ENGINE) {}
+
+  // prettier-ignore
+  function hubSpokeConfigUpdates()
+    public
+    pure
+    override
+    returns (IAaveV4ConfigEngine.SpokeConfigUpdate[] memory)
+  {
+    IAaveV4ConfigEngine.SpokeConfigUpdate[]
+      memory updates = new IAaveV4ConfigEngine.SpokeConfigUpdate[](3);
+
+    uint256 i = 0;
+
+    //                             hub                                  spoke                                    asset                        addCap     drawCap
+    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.EURC, 1_500_000, 1_500_000);
+    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDC, 1_000_000, 950_000);
+    updates[i++] = _capUpdate(AaveV4AvalancheRound12.CORE_HUB,     AaveV4AvalancheRound12.FOREX_SPOKE,      AaveV4AvalancheRound12.USDt, 1_000_000, 950_000);
+
+    require(i == updates.length, 'Invalid number of updates');
+    return updates;
+  }
+
+  function _capUpdate(
+    IHub hub,
+    ISpoke spoke,
+    address underlying,
+    uint256 addCap,
+    uint256 drawCap
+  ) internal pure returns (IAaveV4ConfigEngine.SpokeConfigUpdate memory) {
+    return
+      IAaveV4ConfigEngine.SpokeConfigUpdate({
+        hubConfigurator: AaveV4AvalancheRound12.HUB_CONFIGURATOR,
+        hub: address(hub),
+        underlying: underlying,
+        spoke: address(spoke),
+        addCap: addCap,
+        drawCap: drawCap,
+        riskPremiumThreshold: EngineFlags.KEEP_CURRENT,
+        active: EngineFlags.KEEP_CURRENT,
+        halted: EngineFlags.KEEP_CURRENT
+      });
+  }
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol
@@ -3,27 +3,9 @@ pragma solidity ^0.8.0;
 
 import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Payload.sol';
 import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
-import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
+import {ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
 
-library AaveV4AvalancheRound12 {
-  // https://snowscan.xyz/address/0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c
-  IAaveV4ConfigEngine internal constant CONFIG_ENGINE =
-    IAaveV4ConfigEngine(0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c);
-  // https://snowscan.xyz/address/0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33
-  IHubConfigurator internal constant HUB_CONFIGURATOR =
-    IHubConfigurator(0xbdf92ed96FF6D678469aFAFFa1e7d37B25beaa33);
-  // https://snowscan.xyz/address/0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e
-  IHub internal constant CORE_HUB = IHub(0xd07369fAE4A5BB13c9Ce446B052c7867B1AbDf6e);
-  // https://snowscan.xyz/address/0x6a37776B5E026dBdF043b4F933c323C84DD1B514
-  ISpoke internal constant FOREX_SPOKE = ISpoke(0x6a37776B5E026dBdF043b4F933c323C84DD1B514);
-
-  // https://snowscan.xyz/address/0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD
-  address internal constant EURC = 0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD;
-  // https://snowscan.xyz/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
-  address internal constant USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
-  // https://snowscan.xyz/address/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7
-  address internal constant USDt = 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7;
-}
+import {AaveV4AvalancheRound12} from './AaveV4AvalancheRound12.sol';
 
 /**
  * @title Increase add and draw caps on Avalanche

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
@@ -6,7 +6,8 @@ import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
 import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
 import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
 
-import {AaveV4AvalancheRound12, AaveV4Avalanche_IncreaseCaps_20260803} from './AaveV4Avalanche_IncreaseCaps_20260803.sol';
+import {AaveV4AvalancheRound12} from './AaveV4AvalancheRound12.sol';
+import {AaveV4Avalanche_IncreaseCaps_20260803} from './AaveV4Avalanche_IncreaseCaps_20260803.sol';
 
 import 'aave-helpers/src/ProtocolV4TestBase.sol';
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
@@ -91,7 +91,7 @@ contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     _executePayload();
 
     //                                                                                         addCap     drawCap
-    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    1_500_000, 1_500_000);
+    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    1_600_000, 1_600_000);
     _assertCaps(AaveV4AvalancheRound12.USDC,                                                    1_000_000, 950_000);
     _assertCaps(AaveV4AvalancheRound12.USDt,                                                    1_000_000, 950_000);
   }

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IHub, ISpoke, IAccessManagerEnumerable} from 'aave-address-book/AaveV4.sol';
+import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
+import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
+import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
+
+import {AaveV4AvalancheRound12, AaveV4Avalanche_IncreaseCaps_20260803} from './AaveV4Avalanche_IncreaseCaps_20260803.sol';
+
+import 'aave-helpers/src/ProtocolV4TestBase.sol';
+
+/**
+ * @dev Test for AaveV4Avalanche_IncreaseCaps_20260803
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol -vv
+ */
+contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
+  // https://snowscan.xyz/address/0xe069096bDAfF9bAD15b2f1079EaF0f1685a24522
+  IAccessManagerEnumerable internal constant ACCESS_MANAGER =
+    IAccessManagerEnumerable(0xe069096bDAfF9bAD15b2f1079EaF0f1685a24522);
+
+  // https://snowscan.xyz/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9
+  address internal constant SECURITY_COUNCIL = 0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9;
+  // https://snowscan.xyz/address/0xb619fA61e795D47f517702e63ce50292370561F1
+  address internal constant EXECUTOR = 0xb619fA61e795D47f517702e63ce50292370561F1;
+
+  // https://snowscan.xyz/address/0x435272CefF93a1E657E8ABfdf0A13e95900A3a56
+  ISpoke internal constant MAIN_SPOKE = ISpoke(0x435272CefF93a1E657E8ABfdf0A13e95900A3a56);
+  // https://snowscan.xyz/address/0x3b517594277c67307CF2d7CBE6FE1D4399B68c41
+  ISpoke internal constant AVAX_CORRELATED_SPOKE =
+    ISpoke(0x3b517594277c67307CF2d7CBE6FE1D4399B68c41);
+
+  AaveV4Avalanche_IncreaseCaps_20260803 internal payload;
+
+  function setUp() public virtual {
+    vm.createSelectFork(vm.rpcUrl('avalanche'), 91909536);
+    payload = new AaveV4Avalanche_IncreaseCaps_20260803();
+  }
+
+  function test_executorHasRoleBeforeExecution() public view virtual {
+    (bool hasRole, ) = ACCESS_MANAGER.hasRole(Roles.HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE, EXECUTOR);
+    assertTrue(hasRole, 'Executor should have HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE before execution');
+  }
+
+  function test_roleActiveAfterExecution() public virtual {
+    _executePayload();
+
+    (bool hasRole, ) = ACCESS_MANAGER.hasRole(Roles.HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE, EXECUTOR);
+    assertTrue(hasRole, 'Executor should have HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE after execution');
+  }
+
+  function test_executeWithRecording() public virtual {
+    string memory reportName = 'AaveV4Avalanche_IncreaseCaps_20260803';
+
+    IHub[] memory hubs = new IHub[](1);
+    hubs[0] = AaveV4AvalancheRound12.CORE_HUB;
+
+    ISpoke[] memory spokes = new ISpoke[](3);
+    spokes[0] = MAIN_SPOKE;
+    spokes[1] = AaveV4AvalancheRound12.FOREX_SPOKE;
+    spokes[2] = AVAX_CORRELATED_SPOKE;
+
+    string memory beforeName = string.concat(reportName, '_before');
+    string memory afterName = string.concat(reportName, '_after');
+
+    Types.V4Snapshot memory snapshotBefore = createV4Snapshot(spokes, hubs);
+    writeV4SnapshotJson(beforeName, snapshotBefore);
+
+    (string memory rawDiff, string memory logsJson) = _executePayloadWithRecording();
+
+    Types.V4Snapshot memory snapshotAfter = createV4Snapshot(spokes, hubs);
+    writeV4SnapshotJson(afterName, snapshotAfter);
+
+    string memory afterPath = string.concat('./reports/', afterName, '.json');
+    vm.writeJson(rawDiff, afterPath, '$.raw');
+    vm.writeJson(logsJson, afterPath, '$.logs');
+
+    diffV4Snapshots(reportName);
+  }
+
+  // prettier-ignore
+  function test_caps_before() public view virtual {
+    //                                                                                         addCap   drawCap
+    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    300_000, 400_000);
+    _assertCaps(AaveV4AvalancheRound12.USDC,                                                    400_000, 350_000);
+    _assertCaps(AaveV4AvalancheRound12.USDt,                                                    400_000, 350_000);
+  }
+
+  // prettier-ignore
+  function test_caps() public virtual {
+    _executePayload();
+
+    //                                                                                         addCap     drawCap
+    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    1_500_000, 1_500_000);
+    _assertCaps(AaveV4AvalancheRound12.USDC,                                                    1_000_000, 950_000);
+    _assertCaps(AaveV4AvalancheRound12.USDt,                                                    1_000_000, 950_000);
+  }
+
+  function _executePayload() internal virtual {
+    vm.prank(SECURITY_COUNCIL);
+    IExecutor(EXECUTOR).executeTransaction(address(payload), 0, 'execute()', bytes(''), true);
+  }
+
+  function _assertCaps(
+    address underlying,
+    uint256 expectedAddCap,
+    uint256 expectedDrawCap
+  ) internal view {
+    IHub hub = AaveV4AvalancheRound12.CORE_HUB;
+    IHub.SpokeConfig memory config = hub.getSpokeConfig(
+      hub.getAssetId(underlying),
+      address(AaveV4AvalancheRound12.FOREX_SPOKE)
+    );
+    assertEq(config.addCap, expectedAddCap, 'addCap mismatch');
+    assertEq(config.drawCap, expectedDrawCap, 'drawCap mismatch');
+  }
+
+  function _executePayloadWithRecording()
+    internal
+    returns (string memory rawDiff, string memory logsJson)
+  {
+    uint256 startGas = gasleft();
+    vm.startStateDiffRecording();
+    vm.recordLogs();
+
+    _executePayload();
+
+    uint256 gasUsed = startGas - gasleft();
+    assertLt(gasUsed, (block.gaslimit * 95) / 100, 'BLOCK_GAS_LIMIT_EXCEEDED');
+
+    rawDiff = vm.getStateDiffJson();
+    logsJson = vm.getRecordedLogsJson();
+  }
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol
@@ -6,7 +6,7 @@ import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
 import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
 import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
 
-import {AaveV4AvalancheRound12} from './AaveV4AvalancheRound12.sol';
+import {LocalAaveV4Avalanche} from './LocalV4AddressBook.sol';
 import {AaveV4Avalanche_IncreaseCaps_20260803} from './AaveV4Avalanche_IncreaseCaps_20260803.sol';
 
 import 'aave-helpers/src/ProtocolV4TestBase.sol';
@@ -54,11 +54,11 @@ contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     string memory reportName = 'AaveV4Avalanche_IncreaseCaps_20260803';
 
     IHub[] memory hubs = new IHub[](1);
-    hubs[0] = AaveV4AvalancheRound12.CORE_HUB;
+    hubs[0] = LocalAaveV4Avalanche.CORE_HUB;
 
     ISpoke[] memory spokes = new ISpoke[](3);
     spokes[0] = MAIN_SPOKE;
-    spokes[1] = AaveV4AvalancheRound12.FOREX_SPOKE;
+    spokes[1] = LocalAaveV4Avalanche.FOREX_SPOKE;
     spokes[2] = AVAX_CORRELATED_SPOKE;
 
     string memory beforeName = string.concat(reportName, '_before');
@@ -82,9 +82,9 @@ contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   // prettier-ignore
   function test_caps_before() public view virtual {
     //                                                                                         addCap   drawCap
-    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    300_000, 400_000);
-    _assertCaps(AaveV4AvalancheRound12.USDC,                                                    400_000, 350_000);
-    _assertCaps(AaveV4AvalancheRound12.USDt,                                                    400_000, 350_000);
+    _assertCaps(LocalAaveV4Avalanche.EURC,                                                       300_000, 400_000);
+    _assertCaps(LocalAaveV4Avalanche.USDC,                                                       400_000, 350_000);
+    _assertCaps(LocalAaveV4Avalanche.USDt,                                                       400_000, 350_000);
   }
 
   // prettier-ignore
@@ -92,9 +92,9 @@ contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     _executePayload();
 
     //                                                                                         addCap     drawCap
-    _assertCaps(AaveV4AvalancheRound12.EURC,                                                    1_600_000, 1_600_000);
-    _assertCaps(AaveV4AvalancheRound12.USDC,                                                    1_000_000, 950_000);
-    _assertCaps(AaveV4AvalancheRound12.USDt,                                                    1_000_000, 950_000);
+    _assertCaps(LocalAaveV4Avalanche.EURC,                                                       1_600_000, 1_600_000);
+    _assertCaps(LocalAaveV4Avalanche.USDC,                                                       1_000_000, 950_000);
+    _assertCaps(LocalAaveV4Avalanche.USDt,                                                       1_000_000, 950_000);
   }
 
   function _executePayload() internal virtual {
@@ -107,10 +107,10 @@ contract AaveV4Avalanche_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     uint256 expectedAddCap,
     uint256 expectedDrawCap
   ) internal view {
-    IHub hub = AaveV4AvalancheRound12.CORE_HUB;
+    IHub hub = LocalAaveV4Avalanche.CORE_HUB;
     IHub.SpokeConfig memory config = hub.getSpokeConfig(
       hub.getAssetId(underlying),
-      address(AaveV4AvalancheRound12.FOREX_SPOKE)
+      address(LocalAaveV4Avalanche.FOREX_SPOKE)
     );
     assertEq(config.addCap, expectedAddCap, 'addCap mismatch');
     assertEq(config.drawCap, expectedDrawCap, 'drawCap mismatch');

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803_Fork.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803_Fork.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV4Avalanche_IncreaseCaps_20260803_Test} from './AaveV4Avalanche_IncreaseCaps_20260803.t.sol';
+
+/**
+ * @dev Fork test - forks from a block where the payload has already been executed.
+ * Verifies post-execution state and caps.
+ * Skipped when RPC_TENDERLY_VTESTNET is not set.
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803_Fork.t.sol -vv
+ */
+contract AaveV4Avalanche_IncreaseCaps_20260803_ForkTest is
+  AaveV4Avalanche_IncreaseCaps_20260803_Test
+{
+  function setUp() public override {
+    string memory rpcUrl = vm.envOr('RPC_TENDERLY_VTESTNET', string(''));
+    vm.skip(bytes(rpcUrl).length == 0);
+    vm.createSelectFork(rpcUrl);
+  }
+
+  function test_executeWithRecording() public override {}
+
+  function test_caps_before() public view override {}
+
+  function _executePayload() internal override {}
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
@@ -1,0 +1,77 @@
+---
+title: "Aave V4 Caps Increase #12"
+author: "Llama Risk (implemented by Aave Labs)"
+discussions: "https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c"
+---
+
+## Summary
+
+LlamaRisk recommends a twelfth round of Add Cap and Draw Cap increases for Aave V4.
+This proposal covers the Ethereum and Avalanche deployments and adds a USDG credit line
+from the Ethereum Core Hub to the Maple Spoke.
+
+## Motivation
+
+Utilization and recent growth across the affected Ethereum spokes support additional headroom.
+The Avalanche changes expand the Forex Spoke following continued demand. The new Maple Spoke
+credit line provides an initial 5 million USDG of draw capacity while leaving its Add Cap at zero.
+All configuration parameters other than those specified remain unchanged.
+
+## Specification
+
+### Ethereum
+
+#### Core Hub
+
+| Spoke             | Asset  | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
+| ----------------- | ------ | --------------- | ---------------- | ---------------- | ----------------- |
+| EtherFi           | WETH   | 0               | -                | 20,000           | 30,000            |
+| Forex             | USDG   | 0               | -                | 500,000          | 1,000,000         |
+| Gold              | USDT   | 0               | -                | 2,000,000        | 2,500,000         |
+| Main              | USDG   | 65,000,000      | 75,000,000       | 35,000,000       | 45,000,000        |
+| Main              | USDT   | 20,000,000      | 24,000,000       | 20,000,000       | -                 |
+| Main              | wstETH | 10,000          | 15,000           | 0                | -                 |
+| Tokenization EURC | EURC   | 112,500         | 1,000,000        | 0                | -                 |
+| Tokenization USDC | USDC   | 312,500         | 1,000,000        | 0                | -                 |
+| Tokenization USDG | USDG   | 125,000         | 1,000,000        | 0                | -                 |
+| Tokenization USDT | USDT   | 312,500         | 1,000,000        | 0                | -                 |
+| Bluechip          | USDT   | 0               | -                | 2,500,000        | 4,000,000         |
+| Ethena Ecosystem  | frxUSD | 0               | -                | 500,000          | 1,000,000         |
+
+The proposal also registers USDG from the Core Hub on the Maple Spoke with an Add Cap of zero
+and an initial Draw Cap of 5,000,000. This action assumes the Maple Spoke listing proposal has
+already configured the Spoke and its AccessManager roles.
+
+#### Prime Hub
+
+| Spoke    | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
+| -------- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
+| Bluechip | USDC  | 12,590,000      | 20,000,000       | 14,590,000       | 20,000,000        |
+
+#### Plus Hub
+
+| Spoke            | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
+| ---------------- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
+| Ethena Ecosystem | sUSDe | 8,000,000       | 10,000,000       | 0                | -                 |
+
+### Avalanche
+
+#### Core Hub
+
+| Spoke | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
+| ----- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
+| Forex | EURC  | 300,000         | 1,500,000        | 400,000          | 1,500,000         |
+| Forex | USDC  | 400,000         | 1,000,000        | 350,000          | 950,000           |
+| Forex | USDt  | 400,000         | 1,000,000        | 350,000          | 950,000           |
+
+## References
+
+- Ethereum implementation: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol)
+- Ethereum tests: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol)
+- Avalanche implementation: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol)
+- Avalanche tests: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol)
+- [LlamaRisk recommendation](https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
@@ -36,12 +36,6 @@ parameters other than those specified remain unchanged.
 | Tokenization USDC | USDC   | 312,500         | 1,000,000        | 0                | -                 |
 | Tokenization USDG | USDG   | 125,000         | 1,000,000        | 0                | -                 |
 | Tokenization USDT | USDT   | 312,500         | 1,000,000        | 0                | -                 |
-| Bluechip          | USDT   | 0               | -                | 2,500,000        | 4,000,000         |
-| Ethena Ecosystem  | frxUSD | 0               | -                | 500,000          | 1,000,000         |
-
-The proposal also registers USDG from the Core Hub on the Maple Spoke with an Add Cap of zero
-and an initial Draw Cap of 5,000,000. The Maple Spoke must already be deployed and its
-AccessManager roles configured before this Security Council payload is executed.
 
 #### Prime Hub
 
@@ -56,6 +50,28 @@ AccessManager roles configured before this Security Council payload is executed.
 | Maple syrupUSDG | USDC  | -               | 1,000,000        | -                | 1,000,000         |
 
 USDC is listed as borrowable with collateral disabled (0% collateral factor).
+
+#### Credit Lines
+
+The proposal increases the USDT credit line to the Prime Hub and the frxUSD credit line to the
+Plus Hub, as both existing draw caps have reached near-100% utilization.
+
+| Spoke            | Asset  | Current Draw Cap | Current Draw Util | Proposed Draw Cap |
+| ---------------- | ------ | ---------------- | ----------------- | ----------------- |
+| Bluechip         | USDT   | 2,500,000        | 95%               | 4,000,000         |
+| Ethena Ecosystem | frxUSD | 500,000          | 100%              | 1,000,000         |
+
+Additionally, the proposal establishes a USDG credit line from the Core Hub to the Global Dollar
+Hub, allowing syrupUSDG depositors to access the existing USDG liquidity on the Core Hub.
+
+| Chain    | Direction            | Spoke           | Asset | Proposed Draw Cap |
+| -------- | -------------------- | --------------- | ----- | ----------------- |
+| Ethereum | Core → Global Dollar | Maple syrupUSDG | USDG  | 5,000,000         |
+
+The Maple Spoke is already deployed and listed on the Global Dollar Hub with USDG Add and Draw
+Caps of 10,000,000 and 9,500,000, respectively, and syrupUSDG Add and Draw Caps of 10,000,000 and
+zero. All seven Spoke Configurator selectors are assigned to role 301, so the deployment and
+access-control prerequisites for Security Council execution are satisfied.
 
 ### Avalanche
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
@@ -69,11 +69,9 @@ USDC is listed as borrowable with collateral disabled (0% collateral factor).
 
 ## References
 
-- Ethereum implementation: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol)
-- Ethereum tests: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol)
-- Avalanche implementation: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol)
-- Avalanche tests: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol)
-- [Official governance discussion](https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40)
+- Implementation: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol), [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol)
+- Tests: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol), [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol)
+- [Discussion](https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40)
 
 ## Copyright
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12.md
@@ -1,21 +1,22 @@
 ---
 title: "Aave V4 Caps Increase #12"
 author: "Llama Risk (implemented by Aave Labs)"
-discussions: "https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c"
+discussions: "https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40"
 ---
 
 ## Summary
 
 LlamaRisk recommends a twelfth round of Add Cap and Draw Cap increases for Aave V4.
-This proposal covers the Ethereum and Avalanche deployments and adds a USDG credit line
-from the Ethereum Core Hub to the Maple Spoke.
+This proposal covers the Ethereum and Avalanche deployments, lists USDC on the Maple Spoke
+against the Ethereum Global Dollar Hub, and adds a USDG credit line from the Core Hub.
 
 ## Motivation
 
 Utilization and recent growth across the affected Ethereum spokes support additional headroom.
-The Avalanche changes expand the Forex Spoke following continued demand. The new Maple Spoke
-credit line provides an initial 5 million USDG of draw capacity while leaving its Add Cap at zero.
-All configuration parameters other than those specified remain unchanged.
+The Avalanche changes expand the Forex Spoke following continued demand. The Maple Spoke changes
+add a borrowable, non-collateral USDC reserve with 1 million of Add and Draw capacity and provide
+an initial 5 million USDG Core Hub credit line while leaving its Add Cap at zero. All configuration
+parameters other than those specified remain unchanged.
 
 ## Specification
 
@@ -26,9 +27,9 @@ All configuration parameters other than those specified remain unchanged.
 | Spoke             | Asset  | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
 | ----------------- | ------ | --------------- | ---------------- | ---------------- | ----------------- |
 | EtherFi           | WETH   | 0               | -                | 20,000           | 30,000            |
+| EtherFi           | weETH  | 28,000          | 37,000           | 0                | -                 |
 | Forex             | USDG   | 0               | -                | 500,000          | 1,000,000         |
 | Gold              | USDT   | 0               | -                | 2,000,000        | 2,500,000         |
-| Main              | USDG   | 65,000,000      | 75,000,000       | 35,000,000       | 45,000,000        |
 | Main              | USDT   | 20,000,000      | 24,000,000       | 20,000,000       | -                 |
 | Main              | wstETH | 10,000          | 15,000           | 0                | -                 |
 | Tokenization EURC | EURC   | 112,500         | 1,000,000        | 0                | -                 |
@@ -39,8 +40,8 @@ All configuration parameters other than those specified remain unchanged.
 | Ethena Ecosystem  | frxUSD | 0               | -                | 500,000          | 1,000,000         |
 
 The proposal also registers USDG from the Core Hub on the Maple Spoke with an Add Cap of zero
-and an initial Draw Cap of 5,000,000. This action assumes the Maple Spoke listing proposal has
-already configured the Spoke and its AccessManager roles.
+and an initial Draw Cap of 5,000,000. The Maple Spoke must already be deployed and its
+AccessManager roles configured before this Security Council payload is executed.
 
 #### Prime Hub
 
@@ -48,11 +49,13 @@ already configured the Spoke and its AccessManager roles.
 | -------- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
 | Bluechip | USDC  | 12,590,000      | 20,000,000       | 14,590,000       | 20,000,000        |
 
-#### Plus Hub
+#### Global Dollar Hub
 
-| Spoke            | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
-| ---------------- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
-| Ethena Ecosystem | sUSDe | 8,000,000       | 10,000,000       | 0                | -                 |
+| Spoke           | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
+| --------------- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
+| Maple syrupUSDG | USDC  | -               | 1,000,000        | -                | 1,000,000         |
+
+USDC is listed as borrowable with collateral disabled (0% collateral factor).
 
 ### Avalanche
 
@@ -60,7 +63,7 @@ already configured the Spoke and its AccessManager roles.
 
 | Spoke | Asset | Current Add Cap | Proposed Add Cap | Current Draw Cap | Proposed Draw Cap |
 | ----- | ----- | --------------- | ---------------- | ---------------- | ----------------- |
-| Forex | EURC  | 300,000         | 1,500,000        | 400,000          | 1,500,000         |
+| Forex | EURC  | 300,000         | 1,600,000        | 400,000          | 1,600,000         |
 | Forex | USDC  | 400,000         | 1,000,000        | 350,000          | 950,000           |
 | Forex | USDt  | 400,000         | 1,000,000        | 350,000          | 950,000           |
 
@@ -70,7 +73,7 @@ already configured the Spoke and its AccessManager roles.
 - Ethereum tests: [AaveV4Ethereum](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol)
 - Avalanche implementation: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.sol)
 - Avalanche tests: [AaveV4Avalanche](https://github.com/aave/aave-proposals-v3/blob/main/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Avalanche_IncreaseCaps_20260803.t.sol)
-- [LlamaRisk recommendation](https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c)
+- [Official governance discussion](https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40)
 
 ## Copyright
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12_20260803.s.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12_20260803.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+import {EthereumScript, AvalancheScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+
+import {AaveV4Ethereum_IncreaseCaps_20260803} from './AaveV4Ethereum_IncreaseCaps_20260803.sol';
+import {AaveV4Avalanche_IncreaseCaps_20260803} from './AaveV4Avalanche_IncreaseCaps_20260803.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-account contract=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12_20260803.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AaveV4CapsIncreaseRound12_20260803.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast returns (address) {
+    return
+      GovV3Helpers.deployDeterministic(type(AaveV4Ethereum_IncreaseCaps_20260803).creationCode);
+  }
+}
+
+/**
+ * @dev Deploy Avalanche
+ * deploy-command: make deploy-account contract=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4CapsIncreaseRound12_20260803.s.sol:DeployAvalanche chain=avalanche
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AaveV4CapsIncreaseRound12_20260803.s.sol/43114/run-latest.json
+ */
+contract DeployAvalanche is AvalancheScript {
+  function run() external broadcast returns (address) {
+    return
+      GovV3Helpers.deployDeterministic(type(AaveV4Avalanche_IncreaseCaps_20260803).creationCode);
+  }
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Payload.sol';
 import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
+import {SafeCast} from 'aave-v4/dependencies/openzeppelin/SafeCast.sol';
 import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumSpokePriceFeeds, AaveV4EthereumAssets, ISpoke, IHub} from 'aave-address-book/AaveV4Ethereum.sol';
 
 import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
@@ -14,6 +15,8 @@ import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
  * - To be executed by the Aave Security Council
  */
 contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
+  using SafeCast for uint256;
+
   constructor() AaveV4Payload(AaveV4Ethereum.CONFIG_ENGINE) {}
 
   // prettier-ignore
@@ -33,8 +36,9 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     uint256 i = 0;
 
     //                                   hub            spoke   asset                                     addCap     drawCap
-    additions[i++] = _newCreditLine(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
-    additions[i++] = _newCreditLine(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
+    additions[i++] = _newSpokeAsset(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
+    // New cross-hub credit line from Core
+    additions[i++] = _newSpokeAsset(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
 
     require(i == additions.length, 'Invalid number of additions');
     return additions;
@@ -132,20 +136,20 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
       });
   }
 
-  function _newCreditLine(
+  function _newSpokeAsset(
     IHub hub,
     ISpoke spoke,
     address underlying,
-    uint40 addCap,
-    uint40 drawCap
+    uint256 addCap,
+    uint256 drawCap
   ) internal pure returns (IAaveV4ConfigEngine.SpokeToAssetsAddition memory) {
     IAaveV4ConfigEngine.SpokeAssetConfig[]
       memory assets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
     assets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
       underlying: underlying,
       config: IHub.SpokeConfig({
-        addCap: addCap,
-        drawCap: drawCap,
+        addCap: addCap.toUint40(),
+        drawCap: drawCap.toUint40(),
         riskPremiumThreshold: 0,
         active: true,
         halted: false

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -14,7 +14,7 @@ library AaveV4EthereumRound12 {
 /**
  * @title Increase add and draw caps on Ethereum
  * @author Llama Risk (implemented by Aave Labs)
- * - Discussion: https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c
+ * - Discussion: https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40
  * - To be executed by the Aave Security Council
  */
 contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
@@ -27,8 +27,21 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     returns (IAaveV4ConfigEngine.SpokeToAssetsAddition[] memory)
   {
     IAaveV4ConfigEngine.SpokeAssetConfig[]
-      memory assets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
-    assets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
+      memory usdcAssets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
+    usdcAssets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
+      underlying: AaveV4EthereumAssets.USDC_UNDERLYING,
+      config: IHub.SpokeConfig({
+        addCap: 1_000_000,
+        drawCap: 1_000_000,
+        riskPremiumThreshold: 0,
+        active: true,
+        halted: false
+      })
+    });
+
+    IAaveV4ConfigEngine.SpokeAssetConfig[]
+      memory usdgAssets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
+    usdgAssets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
       underlying: AaveV4EthereumAssets.USDG_UNDERLYING,
       config: IHub.SpokeConfig({
         addCap: 0,
@@ -40,12 +53,18 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     });
 
     IAaveV4ConfigEngine.SpokeToAssetsAddition[]
-      memory additions = new IAaveV4ConfigEngine.SpokeToAssetsAddition[](1);
+      memory additions = new IAaveV4ConfigEngine.SpokeToAssetsAddition[](2);
     additions[0] = IAaveV4ConfigEngine.SpokeToAssetsAddition({
+      hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
+      hub: address(AaveV4EthereumHubs.PAXOS_HUB),
+      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      assets: usdcAssets
+    });
+    additions[1] = IAaveV4ConfigEngine.SpokeToAssetsAddition({
       hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
       hub: address(AaveV4EthereumHubs.CORE_HUB),
       spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
-      assets: assets
+      assets: usdgAssets
     });
     return additions;
   }
@@ -61,10 +80,9 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
 
     IHub CORE = AaveV4EthereumHubs.CORE_HUB;
     IHub PRIME = AaveV4EthereumHubs.PRIME_HUB;
-    IHub PLUS = AaveV4EthereumHubs.PLUS_HUB;
 
     IAaveV4ConfigEngine.SpokeConfigUpdate[]
-      memory updates = new IAaveV4ConfigEngine.SpokeConfigUpdate[](14);
+      memory updates = new IAaveV4ConfigEngine.SpokeConfigUpdate[](13);
 
     uint256 i = 0;
 
@@ -73,9 +91,9 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     // ========================
     //                             hub   spoke                                                                  asset                                       addCap      drawCap
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                            AaveV4EthereumAssets.WETH_UNDERLYING,       KC,         30_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                            AaveV4EthereumAssets.weETH_UNDERLYING,      37_000,     KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.FOREX_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       KC,         1_000_000);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.GOLD_SPOKE),                                AaveV4EthereumAssets.USDT_UNDERLYING,       KC,         2_500_000);
-    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.USDG_UNDERLYING,       75_000_000, 45_000_000);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.USDT_UNDERLYING,       24_000_000, KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.wstETH_UNDERLYING,     15_000,     KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.EURC_UNDERLYING,       1_000_000,  KC);
@@ -91,12 +109,6 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     //                             hub    spoke                                                                 asset                                       addCap      drawCap
     updates[i++] = _capUpdate(PRIME, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                           AaveV4EthereumAssets.USDC_UNDERLYING,       20_000_000, 20_000_000);
 
-    // ========================
-    // Plus Hub
-    // ========================
-    //                             hub   spoke                                                                  asset                                       addCap      drawCap
-    updates[i++] = _capUpdate(PLUS, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                    AaveV4EthereumAssets.sUSDe_UNDERLYING,      10_000_000, KC);
-
     require(i == updates.length, 'Invalid number of updates');
     return updates;
   }
@@ -108,9 +120,28 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     returns (IAaveV4ConfigEngine.ReserveListing[] memory)
   {
     IAaveV4ConfigEngine.ReserveListing[] memory listings = new IAaveV4ConfigEngine.ReserveListing[](
-      1
+      2
     );
     listings[0] = IAaveV4ConfigEngine.ReserveListing({
+      spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
+      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      hub: address(AaveV4EthereumHubs.PAXOS_HUB),
+      underlying: AaveV4EthereumAssets.USDC_UNDERLYING,
+      priceSource: AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDC_PRICE_FEED,
+      config: ISpoke.ReserveConfig({
+        collateralRisk: 0,
+        paused: false,
+        frozen: false,
+        borrowable: true,
+        receiveSharesEnabled: true
+      }),
+      dynamicConfig: ISpoke.DynamicReserveConfig({
+        collateralFactor: 0,
+        maxLiquidationBonus: 100_00,
+        liquidationFee: 0
+      })
+    });
+    listings[1] = IAaveV4ConfigEngine.ReserveListing({
       spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
       spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
       hub: address(AaveV4EthereumHubs.CORE_HUB),

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -17,7 +17,7 @@ import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
 contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
   using SafeCast for uint256;
 
-  constructor() AaveV4Payload(AaveV4Ethereum.CONFIG_ENGINE) {}
+  constructor() AaveV4Payload(LocalAaveV4Ethereum.CONFIG_ENGINE) {}
 
   // prettier-ignore
   function hubSpokeToAssetsAdditions()

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -20,52 +20,27 @@ library AaveV4EthereumRound12 {
 contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
   constructor() AaveV4Payload(AaveV4Ethereum.CONFIG_ENGINE) {}
 
+  // prettier-ignore
   function hubSpokeToAssetsAdditions()
     public
     pure
     override
     returns (IAaveV4ConfigEngine.SpokeToAssetsAddition[] memory)
   {
-    IAaveV4ConfigEngine.SpokeAssetConfig[]
-      memory usdcAssets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
-    usdcAssets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
-      underlying: AaveV4EthereumAssets.USDC_UNDERLYING,
-      config: IHub.SpokeConfig({
-        addCap: 1_000_000,
-        drawCap: 1_000_000,
-        riskPremiumThreshold: 0,
-        active: true,
-        halted: false
-      })
-    });
-
-    IAaveV4ConfigEngine.SpokeAssetConfig[]
-      memory usdgAssets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
-    usdgAssets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
-      underlying: AaveV4EthereumAssets.USDG_UNDERLYING,
-      config: IHub.SpokeConfig({
-        addCap: 0,
-        drawCap: 5_000_000,
-        riskPremiumThreshold: 0,
-        active: true,
-        halted: false
-      })
-    });
+    IHub CORE = AaveV4EthereumHubs.CORE_HUB;
+    IHub GLOBAL_DOLLAR = AaveV4EthereumHubs.PAXOS_HUB;
+    ISpoke MAPLE = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
 
     IAaveV4ConfigEngine.SpokeToAssetsAddition[]
       memory additions = new IAaveV4ConfigEngine.SpokeToAssetsAddition[](2);
-    additions[0] = IAaveV4ConfigEngine.SpokeToAssetsAddition({
-      hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
-      hub: address(AaveV4EthereumHubs.PAXOS_HUB),
-      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
-      assets: usdcAssets
-    });
-    additions[1] = IAaveV4ConfigEngine.SpokeToAssetsAddition({
-      hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
-      hub: address(AaveV4EthereumHubs.CORE_HUB),
-      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
-      assets: usdgAssets
-    });
+
+    uint256 i = 0;
+
+    //                                 hub            spoke   asset                                    addCap     drawCap
+    additions[i++] = _creditLine(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
+    additions[i++] = _creditLine(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
+
+    require(i == additions.length, 'Invalid number of additions');
     return additions;
   }
 
@@ -181,6 +156,35 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
         riskPremiumThreshold: EngineFlags.KEEP_CURRENT,
         active: EngineFlags.KEEP_CURRENT,
         halted: EngineFlags.KEEP_CURRENT
+      });
+  }
+
+  function _creditLine(
+    IHub hub,
+    ISpoke spoke,
+    address underlying,
+    uint40 addCap,
+    uint40 drawCap
+  ) internal pure returns (IAaveV4ConfigEngine.SpokeToAssetsAddition memory) {
+    IAaveV4ConfigEngine.SpokeAssetConfig[]
+      memory assets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
+    assets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
+      underlying: underlying,
+      config: IHub.SpokeConfig({
+        addCap: addCap,
+        drawCap: drawCap,
+        riskPremiumThreshold: 0,
+        active: true,
+        halted: false
+      })
+    });
+
+    return
+      IAaveV4ConfigEngine.SpokeToAssetsAddition({
+        hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
+        hub: address(hub),
+        spoke: address(spoke),
+        assets: assets
       });
   }
 }

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -5,11 +5,7 @@ import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Pa
 import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
 import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumSpokePriceFeeds, AaveV4EthereumAssets, ISpoke, IHub} from 'aave-address-book/AaveV4Ethereum.sol';
 
-library AaveV4EthereumRound12 {
-  // Not available in the address book version pinned by feat/aave-v4.
-  // https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989
-  ISpoke internal constant USDG_MAPLE_ESPOKE = ISpoke(0x774b9655413c34809c1f1b16b654465A89EBE989);
-}
+import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
 
 /**
  * @title Increase add and draw caps on Ethereum
@@ -29,14 +25,14 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
   {
     IHub CORE = AaveV4EthereumHubs.CORE_HUB;
     IHub GLOBAL_DOLLAR = AaveV4EthereumHubs.PAXOS_HUB;
-    ISpoke MAPLE = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
+    ISpoke MAPLE = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE;
 
     IAaveV4ConfigEngine.SpokeToAssetsAddition[]
       memory additions = new IAaveV4ConfigEngine.SpokeToAssetsAddition[](2);
 
     uint256 i = 0;
 
-    //                                 hub            spoke   asset                                    addCap     drawCap
+    //                                   hub            spoke   asset                                     addCap     drawCap
     additions[i++] = _newCreditLine(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
     additions[i++] = _newCreditLine(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
 
@@ -101,7 +97,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
   {
     IHub CORE = AaveV4EthereumHubs.CORE_HUB;
     IHub GLOBAL_DOLLAR = AaveV4EthereumHubs.PAXOS_HUB;
-    ISpoke MAPLE = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
+    ISpoke MAPLE = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE;
 
     IAaveV4ConfigEngine.ReserveListing[] memory listings = new IAaveV4ConfigEngine.ReserveListing[](2);
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV4Payload, IAaveV4ConfigEngine} from 'aave-v4/config-engine/AaveV4Payload.sol';
+import {EngineFlags} from 'aave-v4/config-engine/libraries/EngineFlags.sol';
+import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumSpokePriceFeeds, AaveV4EthereumAssets, ISpoke, IHub} from 'aave-address-book/AaveV4Ethereum.sol';
+
+library AaveV4EthereumRound12 {
+  // Not available in the address book version pinned by feat/aave-v4.
+  // https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989
+  ISpoke internal constant USDG_MAPLE_ESPOKE = ISpoke(0x774b9655413c34809c1f1b16b654465A89EBE989);
+}
+
+/**
+ * @title Increase add and draw caps on Ethereum
+ * @author Llama Risk (implemented by Aave Labs)
+ * - Discussion: https://outline.llamarisk.com/s/a3e1d391-6199-4123-b6f5-62b687235c6c
+ * - To be executed by the Aave Security Council
+ */
+contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
+  constructor() AaveV4Payload(AaveV4Ethereum.CONFIG_ENGINE) {}
+
+  function hubSpokeToAssetsAdditions()
+    public
+    pure
+    override
+    returns (IAaveV4ConfigEngine.SpokeToAssetsAddition[] memory)
+  {
+    IAaveV4ConfigEngine.SpokeAssetConfig[]
+      memory assets = new IAaveV4ConfigEngine.SpokeAssetConfig[](1);
+    assets[0] = IAaveV4ConfigEngine.SpokeAssetConfig({
+      underlying: AaveV4EthereumAssets.USDG_UNDERLYING,
+      config: IHub.SpokeConfig({
+        addCap: 0,
+        drawCap: 5_000_000,
+        riskPremiumThreshold: 0,
+        active: true,
+        halted: false
+      })
+    });
+
+    IAaveV4ConfigEngine.SpokeToAssetsAddition[]
+      memory additions = new IAaveV4ConfigEngine.SpokeToAssetsAddition[](1);
+    additions[0] = IAaveV4ConfigEngine.SpokeToAssetsAddition({
+      hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
+      hub: address(AaveV4EthereumHubs.CORE_HUB),
+      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      assets: assets
+    });
+    return additions;
+  }
+
+  // prettier-ignore
+  function hubSpokeConfigUpdates()
+    public
+    pure
+    override
+    returns (IAaveV4ConfigEngine.SpokeConfigUpdate[] memory)
+  {
+    uint256 KC = EngineFlags.KEEP_CURRENT;
+
+    IHub CORE = AaveV4EthereumHubs.CORE_HUB;
+    IHub PRIME = AaveV4EthereumHubs.PRIME_HUB;
+    IHub PLUS = AaveV4EthereumHubs.PLUS_HUB;
+
+    IAaveV4ConfigEngine.SpokeConfigUpdate[]
+      memory updates = new IAaveV4ConfigEngine.SpokeConfigUpdate[](14);
+
+    uint256 i = 0;
+
+    // ========================
+    // Core Hub
+    // ========================
+    //                             hub   spoke                                                                  asset                                       addCap      drawCap
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                            AaveV4EthereumAssets.WETH_UNDERLYING,       KC,         30_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.FOREX_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       KC,         1_000_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.GOLD_SPOKE),                                AaveV4EthereumAssets.USDT_UNDERLYING,       KC,         2_500_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.USDG_UNDERLYING,       75_000_000, 45_000_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.USDT_UNDERLYING,       24_000_000, KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.MAIN_SPOKE),                                AaveV4EthereumAssets.wstETH_UNDERLYING,     15_000,     KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.EURC_UNDERLYING,       1_000_000,  KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDC_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDC_UNDERLYING,       1_000_000,  KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDG_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDG_UNDERLYING,       1_000_000,  KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDT_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDT_UNDERLYING,       1_000_000,  KC);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                            AaveV4EthereumAssets.USDT_UNDERLYING,       KC,         4_000_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                    AaveV4EthereumAssets.frxUSD_UNDERLYING,     KC,         1_000_000);
+
+    // ========================
+    // Prime Hub
+    // ========================
+    //                             hub    spoke                                                                 asset                                       addCap      drawCap
+    updates[i++] = _capUpdate(PRIME, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                           AaveV4EthereumAssets.USDC_UNDERLYING,       20_000_000, 20_000_000);
+
+    // ========================
+    // Plus Hub
+    // ========================
+    //                             hub   spoke                                                                  asset                                       addCap      drawCap
+    updates[i++] = _capUpdate(PLUS, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                    AaveV4EthereumAssets.sUSDe_UNDERLYING,      10_000_000, KC);
+
+    require(i == updates.length, 'Invalid number of updates');
+    return updates;
+  }
+
+  function spokeReserveListings()
+    public
+    pure
+    override
+    returns (IAaveV4ConfigEngine.ReserveListing[] memory)
+  {
+    IAaveV4ConfigEngine.ReserveListing[] memory listings = new IAaveV4ConfigEngine.ReserveListing[](
+      1
+    );
+    listings[0] = IAaveV4ConfigEngine.ReserveListing({
+      spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
+      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      hub: address(AaveV4EthereumHubs.CORE_HUB),
+      underlying: AaveV4EthereumAssets.USDG_UNDERLYING,
+      priceSource: AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDG_PRICE_FEED,
+      config: ISpoke.ReserveConfig({
+        collateralRisk: 0,
+        paused: false,
+        frozen: false,
+        borrowable: true,
+        receiveSharesEnabled: true
+      }),
+      dynamicConfig: ISpoke.DynamicReserveConfig({
+        collateralFactor: 0,
+        maxLiquidationBonus: 100_00,
+        liquidationFee: 0
+      })
+    });
+    return listings;
+  }
+
+  function _capUpdate(
+    IHub hub,
+    address spoke,
+    address underlying,
+    uint256 addCap,
+    uint256 drawCap
+  ) internal pure returns (IAaveV4ConfigEngine.SpokeConfigUpdate memory) {
+    return
+      IAaveV4ConfigEngine.SpokeConfigUpdate({
+        hubConfigurator: AaveV4Ethereum.HUB_CONFIGURATOR,
+        hub: address(hub),
+        underlying: underlying,
+        spoke: spoke,
+        addCap: addCap,
+        drawCap: drawCap,
+        riskPremiumThreshold: EngineFlags.KEEP_CURRENT,
+        active: EngineFlags.KEEP_CURRENT,
+        halted: EngineFlags.KEEP_CURRENT
+      });
+  }
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -8,7 +8,7 @@ import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4Ethereum
 import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
 
 /**
- * @title Increase add and draw caps on Ethereum
+ * @title Increase add and draw caps on Core and Prime Hubs, add a credit line and list reserves
  * @author Llama Risk (implemented by Aave Labs)
  * - Discussion: https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40
  * - To be executed by the Aave Security Council

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.sol
@@ -37,8 +37,8 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     uint256 i = 0;
 
     //                                 hub            spoke   asset                                    addCap     drawCap
-    additions[i++] = _creditLine(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
-    additions[i++] = _creditLine(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
+    additions[i++] = _newCreditLine(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      1_000_000, 1_000_000);
+    additions[i++] = _newCreditLine(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      0,         5_000_000);
 
     require(i == additions.length, 'Invalid number of additions');
     return additions;
@@ -64,7 +64,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     // ========================
     // Core Hub
     // ========================
-    //                             hub   spoke                                                                  asset                                       addCap      drawCap
+    //                             hub   spoke                                                                    asset                                       addCap      drawCap
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                            AaveV4EthereumAssets.WETH_UNDERLYING,       KC,         30_000);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                            AaveV4EthereumAssets.weETH_UNDERLYING,      37_000,     KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.FOREX_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       KC,         1_000_000);
@@ -75,66 +75,43 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDC_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDC_UNDERLYING,       1_000_000,  KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDG_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDG_UNDERLYING,       1_000_000,  KC);
     updates[i++] = _capUpdate(CORE, address(AaveV4EthereumTokenizationSpokes.CORE_USDT_TOKENIZATION_SPOKE),  AaveV4EthereumAssets.USDT_UNDERLYING,       1_000_000,  KC);
-    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                            AaveV4EthereumAssets.USDT_UNDERLYING,       KC,         4_000_000);
-    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                    AaveV4EthereumAssets.frxUSD_UNDERLYING,     KC,         1_000_000);
-
     // ========================
     // Prime Hub
     // ========================
-    //                             hub    spoke                                                                 asset                                       addCap      drawCap
+    //                             hub    spoke                                                                   asset                                       addCap      drawCap
     updates[i++] = _capUpdate(PRIME, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                           AaveV4EthereumAssets.USDC_UNDERLYING,       20_000_000, 20_000_000);
+
+    // ========================
+    // Credit Lines
+    // ========================
+    //                             hub   spoke                                                                    asset                                       addCap      drawCap
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                            AaveV4EthereumAssets.USDT_UNDERLYING,       KC,         4_000_000);
+    updates[i++] = _capUpdate(CORE, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                    AaveV4EthereumAssets.frxUSD_UNDERLYING,     KC,         1_000_000);
 
     require(i == updates.length, 'Invalid number of updates');
     return updates;
   }
 
+  // prettier-ignore
   function spokeReserveListings()
     public
     pure
     override
     returns (IAaveV4ConfigEngine.ReserveListing[] memory)
   {
-    IAaveV4ConfigEngine.ReserveListing[] memory listings = new IAaveV4ConfigEngine.ReserveListing[](
-      2
-    );
-    listings[0] = IAaveV4ConfigEngine.ReserveListing({
-      spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
-      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
-      hub: address(AaveV4EthereumHubs.PAXOS_HUB),
-      underlying: AaveV4EthereumAssets.USDC_UNDERLYING,
-      priceSource: AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDC_PRICE_FEED,
-      config: ISpoke.ReserveConfig({
-        collateralRisk: 0,
-        paused: false,
-        frozen: false,
-        borrowable: true,
-        receiveSharesEnabled: true
-      }),
-      dynamicConfig: ISpoke.DynamicReserveConfig({
-        collateralFactor: 0,
-        maxLiquidationBonus: 100_00,
-        liquidationFee: 0
-      })
-    });
-    listings[1] = IAaveV4ConfigEngine.ReserveListing({
-      spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
-      spoke: address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
-      hub: address(AaveV4EthereumHubs.CORE_HUB),
-      underlying: AaveV4EthereumAssets.USDG_UNDERLYING,
-      priceSource: AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDG_PRICE_FEED,
-      config: ISpoke.ReserveConfig({
-        collateralRisk: 0,
-        paused: false,
-        frozen: false,
-        borrowable: true,
-        receiveSharesEnabled: true
-      }),
-      dynamicConfig: ISpoke.DynamicReserveConfig({
-        collateralFactor: 0,
-        maxLiquidationBonus: 100_00,
-        liquidationFee: 0
-      })
-    });
+    IHub CORE = AaveV4EthereumHubs.CORE_HUB;
+    IHub GLOBAL_DOLLAR = AaveV4EthereumHubs.PAXOS_HUB;
+    ISpoke MAPLE = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
+
+    IAaveV4ConfigEngine.ReserveListing[] memory listings = new IAaveV4ConfigEngine.ReserveListing[](2);
+
+    uint256 i = 0;
+
+    //                                      hub            spoke  asset                                      priceSource
+    listings[i++] = _newReserveListing(GLOBAL_DOLLAR, MAPLE, AaveV4EthereumAssets.USDC_UNDERLYING,      AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDC_PRICE_FEED);
+    listings[i++] = _newReserveListing(CORE,          MAPLE, AaveV4EthereumAssets.USDG_UNDERLYING,      AaveV4EthereumSpokePriceFeeds.MAIN_SPOKE_USDG_PRICE_FEED);
+
+    require(i == listings.length, 'Invalid number of listings');
     return listings;
   }
 
@@ -159,7 +136,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
       });
   }
 
-  function _creditLine(
+  function _newCreditLine(
     IHub hub,
     ISpoke spoke,
     address underlying,
@@ -185,6 +162,34 @@ contract AaveV4Ethereum_IncreaseCaps_20260803 is AaveV4Payload {
         hub: address(hub),
         spoke: address(spoke),
         assets: assets
+      });
+  }
+
+  function _newReserveListing(
+    IHub hub,
+    ISpoke spoke,
+    address underlying,
+    address priceSource
+  ) internal pure returns (IAaveV4ConfigEngine.ReserveListing memory) {
+    return
+      IAaveV4ConfigEngine.ReserveListing({
+        spokeConfigurator: AaveV4Ethereum.SPOKE_CONFIGURATOR,
+        spoke: address(spoke),
+        hub: address(hub),
+        underlying: underlying,
+        priceSource: priceSource,
+        config: ISpoke.ReserveConfig({
+          collateralRisk: 0,
+          paused: false,
+          frozen: false,
+          borrowable: true,
+          receiveSharesEnabled: true
+        }),
+        dynamicConfig: ISpoke.DynamicReserveConfig({
+          collateralFactor: 0,
+          maxLiquidationBonus: 100_00,
+          liquidationFee: 0
+        })
       });
   }
 }

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
@@ -27,6 +27,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   IHub internal constant CORE_HUB = AaveV4EthereumHubs.CORE_HUB;
   IHub internal constant PRIME_HUB = AaveV4EthereumHubs.PRIME_HUB;
   IHub internal constant PLUS_HUB = AaveV4EthereumHubs.PLUS_HUB;
+  IHub internal constant GLOBAL_DOLLAR_HUB = AaveV4EthereumHubs.PAXOS_HUB;
 
   function setUp() public virtual {
     vm.createSelectFork(vm.rpcUrl('mainnet'), 25673317);
@@ -125,9 +126,9 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   function test_caps_coreHub_before() public view virtual {
     //                  hub       spoke                                                                 asset                                       addCap      drawCap
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.WETH_UNDERLYING,       0,          20_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.weETH_UNDERLYING,      28_000,     0);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.FOREX_SPOKE),                              AaveV4EthereumAssets.USDG_UNDERLYING,       0,          500_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.GOLD_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       0,          2_000_000);
-    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       65_000_000, 35_000_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       20_000_000, 20_000_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.wstETH_UNDERLYING,     10_000,     0);
     _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.EURC_UNDERLYING,       112_500,    0);
@@ -144,9 +145,9 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
 
     //                  hub       spoke                                                                 asset                                       addCap      drawCap
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.WETH_UNDERLYING,       0,          30_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.weETH_UNDERLYING,      37_000,     0);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.FOREX_SPOKE),                              AaveV4EthereumAssets.USDG_UNDERLYING,       0,          1_000_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.GOLD_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       0,          2_500_000);
-    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       75_000_000, 45_000_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       24_000_000, 20_000_000);
     _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.wstETH_UNDERLYING,     15_000,     0);
     _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.EURC_UNDERLYING,       1_000_000,  0);
@@ -172,52 +173,79 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   }
 
   // prettier-ignore
-  function test_caps_plusHub_before() public view virtual {
-    //                  hub       spoke                                                       asset                                       addCap     drawCap
-    _assertCaps(PLUS_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE), AaveV4EthereumAssets.sUSDe_UNDERLYING, 8_000_000, 0);
-  }
-
-  // prettier-ignore
-  function test_caps_plusHub() public virtual {
+  function test_omittedCapsRemainUnchanged() public virtual {
     _executePayload();
 
     //                  hub       spoke                                                       asset                                       addCap      drawCap
-    _assertCaps(PLUS_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE), AaveV4EthereumAssets.sUSDe_UNDERLYING, 10_000_000, 0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),              AaveV4EthereumAssets.USDG_UNDERLYING,  65_000_000, 35_000_000);
+    _assertCaps(PLUS_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),   AaveV4EthereumAssets.sUSDe_UNDERLYING, 8_000_000,  0);
   }
 
-  function test_mapleCreditLine_before() public view virtual {
-    uint256 assetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
+  function test_mapleListings_before() public view virtual {
+    uint256 usdcAssetId = GLOBAL_DOLLAR_HUB.getAssetId(AaveV4EthereumAssets.USDC_UNDERLYING);
     assertFalse(
-      CORE_HUB.isSpokeListed(assetId, address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)),
+      GLOBAL_DOLLAR_HUB.isSpokeListed(
+        usdcAssetId,
+        address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)
+      ),
+      'Maple Spoke should not have Global Dollar USDC before execution'
+    );
+
+    uint256 usdgAssetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
+    assertFalse(
+      CORE_HUB.isSpokeListed(usdgAssetId, address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)),
       'Maple Spoke should not have Core USDG before execution'
     );
   }
 
-  function test_mapleCreditLine() public virtual {
+  function test_mapleListings() public virtual {
     _executePayload();
 
-    uint256 assetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
     address mapleSpoke = address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE);
-    assertTrue(CORE_HUB.isSpokeListed(assetId, mapleSpoke), 'Maple Spoke should be listed');
-
-    _assertCaps(CORE_HUB, mapleSpoke, AaveV4EthereumAssets.USDG_UNDERLYING, 0, 5_000_000);
-
-    uint256 reserveId = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveId(
-      address(CORE_HUB),
-      assetId
+    uint256 usdcAssetId = GLOBAL_DOLLAR_HUB.getAssetId(AaveV4EthereumAssets.USDC_UNDERLYING);
+    assertTrue(
+      GLOBAL_DOLLAR_HUB.isSpokeListed(usdcAssetId, mapleSpoke),
+      'Maple Spoke should have Global Dollar USDC'
     );
+    _assertCaps(
+      GLOBAL_DOLLAR_HUB,
+      mapleSpoke,
+      AaveV4EthereumAssets.USDC_UNDERLYING,
+      1_000_000,
+      1_000_000
+    );
+    _assertMapleReserve(GLOBAL_DOLLAR_HUB, AaveV4EthereumAssets.USDC_UNDERLYING);
+
+    uint256 usdgAssetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
+    assertTrue(
+      CORE_HUB.isSpokeListed(usdgAssetId, mapleSpoke),
+      'Maple Spoke should have Core USDG'
+    );
+    _assertCaps(CORE_HUB, mapleSpoke, AaveV4EthereumAssets.USDG_UNDERLYING, 0, 5_000_000);
+    _assertMapleReserve(CORE_HUB, AaveV4EthereumAssets.USDG_UNDERLYING);
+  }
+
+  function _assertMapleReserve(IHub hub, address underlying) internal view {
+    uint256 assetId = hub.getAssetId(underlying);
+    uint256 reserveId = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveId(address(hub), assetId);
     ISpoke.Reserve memory reserve = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserve(reserveId);
     ISpoke.ReserveConfig memory config = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveConfig(
       reserveId
     );
-    assertEq(reserve.underlying, AaveV4EthereumAssets.USDG_UNDERLYING, 'underlying mismatch');
-    assertEq(address(reserve.hub), address(CORE_HUB), 'hub mismatch');
+    ISpoke.DynamicReserveConfig memory dynamicConfig = AaveV4EthereumRound12
+      .USDG_MAPLE_ESPOKE
+      .getDynamicReserveConfig(reserveId, reserve.dynamicConfigKey);
+    assertEq(reserve.underlying, underlying, 'underlying mismatch');
+    assertEq(address(reserve.hub), address(hub), 'hub mismatch');
     assertEq(uint256(reserve.assetId), assetId, 'assetId mismatch');
     assertEq(uint256(config.collateralRisk), 0, 'collateralRisk mismatch');
     assertFalse(config.paused, 'reserve should not be paused');
     assertFalse(config.frozen, 'reserve should not be frozen');
     assertTrue(config.borrowable, 'reserve should be borrowable');
     assertTrue(config.receiveSharesEnabled, 'receiveShares should be enabled');
+    assertEq(uint256(dynamicConfig.collateralFactor), 0, 'collateralFactor mismatch');
+    assertEq(uint256(dynamicConfig.maxLiquidationBonus), 100_00, 'liquidationBonus mismatch');
+    assertEq(uint256(dynamicConfig.liquidationFee), 0, 'liquidationFee mismatch');
   }
 
   // ================================================================

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IHub, IAccessManagerEnumerable, ISpoke} from 'aave-address-book/AaveV4.sol';
+import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
+import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumAssets, AaveV4EthereumGetters} from 'aave-address-book/AaveV4Ethereum.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
+import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
+
+import {AaveV4EthereumRound12, AaveV4Ethereum_IncreaseCaps_20260803} from './AaveV4Ethereum_IncreaseCaps_20260803.sol';
+
+import 'aave-helpers/src/ProtocolV4TestBase.sol';
+
+/**
+ * @dev Test for AaveV4Ethereum_IncreaseCaps_20260803
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol -vv
+ */
+contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
+  AaveV4Ethereum_IncreaseCaps_20260803 internal payload;
+
+  IAccessManagerEnumerable internal constant ACCESS_MANAGER = AaveV4Ethereum.ACCESS_MANAGER;
+
+  address internal constant SECURITY_COUNCIL = 0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9;
+  address internal constant EXECUTOR = 0x14339e2178A954d5FB839D5Ff31644fE0F25F517;
+
+  IHub internal constant CORE_HUB = AaveV4EthereumHubs.CORE_HUB;
+  IHub internal constant PRIME_HUB = AaveV4EthereumHubs.PRIME_HUB;
+  IHub internal constant PLUS_HUB = AaveV4EthereumHubs.PLUS_HUB;
+
+  function setUp() public virtual {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 25673317);
+
+    // The Maple listing proposal performs this AccessManager setup through Governance before
+    // this Security Council payload is executed.
+    vm.prank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    ACCESS_MANAGER.setTargetFunctionRole(
+      address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      Roles.getSpokeConfiguratorRoleSelectors(),
+      Roles.SPOKE_CONFIGURATOR_ROLE
+    );
+
+    payload = new AaveV4Ethereum_IncreaseCaps_20260803();
+  }
+
+  // ================================================================
+  // Execution & roles
+  // ================================================================
+
+  function test_executorHasRoleBeforeExecution() public view virtual {
+    (bool hasRole, ) = ACCESS_MANAGER.hasRole(Roles.HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE, EXECUTOR);
+    assertTrue(hasRole, 'Executor should have HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE before execution');
+  }
+
+  function test_rolesActiveAfterExecution() public virtual {
+    _executePayload();
+
+    (bool hasHubRole, ) = ACCESS_MANAGER.hasRole(
+      Roles.HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE,
+      EXECUTOR
+    );
+    assertTrue(hasHubRole, 'Executor should have HUB_CONFIGURATOR_DOMAIN_ADMIN_ROLE');
+
+    (bool hasSpokeRole, ) = ACCESS_MANAGER.hasRole(
+      Roles.SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE,
+      EXECUTOR
+    );
+    assertTrue(hasSpokeRole, 'Executor should have SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE');
+  }
+
+  function test_executeWithRecording() public virtual {
+    string memory reportName = 'AaveV4Ethereum_IncreaseCaps_20260803';
+
+    IHub[] memory hubs = AaveV4EthereumGetters.getAllHubs();
+    ISpoke[] memory spokes = _allSpokesWithMaple();
+    address[] memory positionManagerCandidates = _positionManagerCandidates();
+    address[] memory accessManagers = _accessManagers();
+
+    string memory beforeName = string.concat(reportName, '_before');
+    string memory afterName = string.concat(reportName, '_after');
+
+    Types.V4Snapshot memory snapshotBefore = createV4Snapshot(
+      spokes,
+      hubs,
+      positionManagerCandidates,
+      accessManagers
+    );
+    writeV4SnapshotJson(beforeName, snapshotBefore);
+
+    (string memory rawDiff, string memory logsJson) = _executePayloadWithRecording();
+
+    Types.V4Snapshot memory snapshotAfter = createV4Snapshot(
+      spokes,
+      hubs,
+      positionManagerCandidates,
+      accessManagers
+    );
+    writeV4SnapshotJson(afterName, snapshotAfter);
+
+    string memory afterPath = string.concat('./reports/', afterName, '.json');
+    vm.writeJson(rawDiff, afterPath, '$.raw');
+    vm.writeJson(logsJson, afterPath, '$.logs');
+
+    diffV4Snapshots(reportName);
+  }
+
+  // ================================================================
+  // E2E tests (supply, borrow, repay, liquidation, tokenization, gateways)
+  // ================================================================
+
+  function test_e2e() public virtual {
+    _executePayload();
+
+    vm.pauseGasMetering();
+    e2eTestAllSpokes({spokes: AaveV4EthereumGetters.getAllSpokes(), testPositionManagers: true});
+    e2eTestAllTokenizationSpokes(AaveV4EthereumGetters.getAllTokenizationSpokes());
+    vm.resumeGasMetering();
+  }
+
+  // ================================================================
+  // Cap updates
+  // ================================================================
+
+  // prettier-ignore
+  function test_caps_coreHub_before() public view virtual {
+    //                  hub       spoke                                                                 asset                                       addCap      drawCap
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.WETH_UNDERLYING,       0,          20_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.FOREX_SPOKE),                              AaveV4EthereumAssets.USDG_UNDERLYING,       0,          500_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.GOLD_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       0,          2_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       65_000_000, 35_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       20_000_000, 20_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.wstETH_UNDERLYING,     10_000,     0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.EURC_UNDERLYING,       112_500,    0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDC_UNDERLYING,       312_500,    0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDG_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDG_UNDERLYING,       125_000,    0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDT_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDT_UNDERLYING,       312_500,    0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                           AaveV4EthereumAssets.USDT_UNDERLYING,       0,          2_500_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                   AaveV4EthereumAssets.frxUSD_UNDERLYING,     0,          500_000);
+  }
+
+  // prettier-ignore
+  function test_caps_coreHub() public virtual {
+    _executePayload();
+
+    //                  hub       spoke                                                                 asset                                       addCap      drawCap
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHERFI_ESPOKE),                           AaveV4EthereumAssets.WETH_UNDERLYING,       0,          30_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.FOREX_SPOKE),                              AaveV4EthereumAssets.USDG_UNDERLYING,       0,          1_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.GOLD_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       0,          2_500_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDG_UNDERLYING,       75_000_000, 45_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.USDT_UNDERLYING,       24_000_000, 20_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.MAIN_SPOKE),                               AaveV4EthereumAssets.wstETH_UNDERLYING,     15_000,     0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_EURC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.EURC_UNDERLYING,       1_000_000,  0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDC_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDC_UNDERLYING,       1_000_000,  0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDG_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDG_UNDERLYING,       1_000_000,  0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumTokenizationSpokes.CORE_USDT_TOKENIZATION_SPOKE), AaveV4EthereumAssets.USDT_UNDERLYING,       1_000_000,  0);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE),                           AaveV4EthereumAssets.USDT_UNDERLYING,       0,          4_000_000);
+    _assertCaps(CORE_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE),                   AaveV4EthereumAssets.frxUSD_UNDERLYING,     0,          1_000_000);
+  }
+
+  // prettier-ignore
+  function test_caps_primeHub_before() public view virtual {
+    //                   hub        spoke                                              asset                                       addCap      drawCap
+    _assertCaps(PRIME_HUB, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE), AaveV4EthereumAssets.USDC_UNDERLYING, 12_590_000, 14_590_000);
+  }
+
+  // prettier-ignore
+  function test_caps_primeHub() public virtual {
+    _executePayload();
+
+    //                   hub        spoke                                              asset                                       addCap      drawCap
+    _assertCaps(PRIME_HUB, address(AaveV4EthereumSpokes.BLUECHIP_SPOKE), AaveV4EthereumAssets.USDC_UNDERLYING, 20_000_000, 20_000_000);
+  }
+
+  // prettier-ignore
+  function test_caps_plusHub_before() public view virtual {
+    //                  hub       spoke                                                       asset                                       addCap     drawCap
+    _assertCaps(PLUS_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE), AaveV4EthereumAssets.sUSDe_UNDERLYING, 8_000_000, 0);
+  }
+
+  // prettier-ignore
+  function test_caps_plusHub() public virtual {
+    _executePayload();
+
+    //                  hub       spoke                                                       asset                                       addCap      drawCap
+    _assertCaps(PLUS_HUB, address(AaveV4EthereumSpokes.ETHENA_ECOSYSTEM_SPOKE), AaveV4EthereumAssets.sUSDe_UNDERLYING, 10_000_000, 0);
+  }
+
+  function test_mapleCreditLine_before() public view virtual {
+    uint256 assetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
+    assertFalse(
+      CORE_HUB.isSpokeListed(assetId, address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)),
+      'Maple Spoke should not have Core USDG before execution'
+    );
+  }
+
+  function test_mapleCreditLine() public virtual {
+    _executePayload();
+
+    uint256 assetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
+    address mapleSpoke = address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE);
+    assertTrue(CORE_HUB.isSpokeListed(assetId, mapleSpoke), 'Maple Spoke should be listed');
+
+    _assertCaps(CORE_HUB, mapleSpoke, AaveV4EthereumAssets.USDG_UNDERLYING, 0, 5_000_000);
+
+    uint256 reserveId = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveId(
+      address(CORE_HUB),
+      assetId
+    );
+    ISpoke.Reserve memory reserve = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserve(reserveId);
+    ISpoke.ReserveConfig memory config = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveConfig(
+      reserveId
+    );
+    assertEq(reserve.underlying, AaveV4EthereumAssets.USDG_UNDERLYING, 'underlying mismatch');
+    assertEq(address(reserve.hub), address(CORE_HUB), 'hub mismatch');
+    assertEq(uint256(reserve.assetId), assetId, 'assetId mismatch');
+    assertEq(uint256(config.collateralRisk), 0, 'collateralRisk mismatch');
+    assertFalse(config.paused, 'reserve should not be paused');
+    assertFalse(config.frozen, 'reserve should not be frozen');
+    assertTrue(config.borrowable, 'reserve should be borrowable');
+    assertTrue(config.receiveSharesEnabled, 'receiveShares should be enabled');
+  }
+
+  // ================================================================
+  // Helpers
+  // ================================================================
+
+  function _executePayload() internal virtual {
+    vm.prank(SECURITY_COUNCIL);
+    IExecutor(EXECUTOR).executeTransaction(address(payload), 0, 'execute()', bytes(''), true);
+  }
+
+  function _assertCaps(
+    IHub hub,
+    address spoke,
+    address underlying,
+    uint256 expectedAddCap,
+    uint256 expectedDrawCap
+  ) internal view {
+    uint256 assetId = hub.getAssetId(underlying);
+    IHub.SpokeConfig memory config = hub.getSpokeConfig(assetId, spoke);
+    assertEq(config.addCap, expectedAddCap, 'addCap mismatch');
+    assertEq(config.drawCap, expectedDrawCap, 'drawCap mismatch');
+  }
+
+  function _allSpokesWithMaple() internal pure returns (ISpoke[] memory) {
+    ISpoke[] memory currentSpokes = AaveV4EthereumGetters.getAllSpokes();
+    ISpoke[] memory spokes = new ISpoke[](currentSpokes.length + 1);
+    for (uint256 i; i < currentSpokes.length; ++i) {
+      spokes[i] = currentSpokes[i];
+    }
+    spokes[currentSpokes.length] = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
+    return spokes;
+  }
+
+  function _executePayloadWithRecording()
+    internal
+    returns (string memory rawDiff, string memory logsJson)
+  {
+    uint256 startGas = gasleft();
+    vm.startStateDiffRecording();
+    vm.recordLogs();
+
+    _executePayload();
+
+    uint256 gasUsed = startGas - gasleft();
+    assertLt(gasUsed, (block.gaslimit * 95) / 100, 'BLOCK_GAS_LIMIT_EXCEEDED');
+
+    rawDiff = vm.getStateDiffJson();
+    logsJson = vm.getRecordedLogsJson();
+  }
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IHub, IAccessManagerEnumerable, ISpoke} from 'aave-address-book/AaveV4.sol';
+import {IHub, IAccessManagerEnumerable, ISpoke, ITokenizationSpoke} from 'aave-address-book/AaveV4.sol';
 import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
 import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumAssets, AaveV4EthereumGetters} from 'aave-address-book/AaveV4Ethereum.sol';
 import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
@@ -104,8 +104,8 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     _executePayload();
 
     vm.pauseGasMetering();
-    e2eTestAllSpokes({spokes: AaveV4EthereumGetters.getAllSpokes(), testPositionManagers: true});
-    e2eTestAllTokenizationSpokes(AaveV4EthereumGetters.getAllTokenizationSpokes());
+    e2eTestAllSpokes({spokes: _allSpokesWithMaple(), testPositionManagers: true});
+    e2eTestAllTokenizationSpokes(_allTokenizationSpokesWithGlobalDollarUsdg());
     vm.resumeGasMetering();
   }
 
@@ -265,6 +265,20 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
       spokes[i] = currentSpokes[i];
     }
     spokes[currentSpokes.length] = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE;
+    return spokes;
+  }
+
+  function _allTokenizationSpokesWithGlobalDollarUsdg()
+    internal
+    pure
+    returns (ITokenizationSpoke[] memory)
+  {
+    ITokenizationSpoke[] memory currentSpokes = AaveV4EthereumGetters.getAllTokenizationSpokes();
+    ITokenizationSpoke[] memory spokes = new ITokenizationSpoke[](currentSpokes.length + 1);
+    for (uint256 i; i < currentSpokes.length; ++i) {
+      spokes[i] = currentSpokes[i];
+    }
+    spokes[currentSpokes.length] = LocalAaveV4Ethereum.GLOBAL_DOLLAR_USDG_TOKENIZATION_SPOKE;
     return spokes;
   }
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
@@ -8,7 +8,8 @@ import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
 import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
 import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
 
-import {AaveV4EthereumRound12, AaveV4Ethereum_IncreaseCaps_20260803} from './AaveV4Ethereum_IncreaseCaps_20260803.sol';
+import {LocalAaveV4Ethereum} from './LocalV4AddressBook.sol';
+import {AaveV4Ethereum_IncreaseCaps_20260803} from './AaveV4Ethereum_IncreaseCaps_20260803.sol';
 
 import 'aave-helpers/src/ProtocolV4TestBase.sol';
 
@@ -36,7 +37,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     // this Security Council payload is executed.
     vm.prank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
     ACCESS_MANAGER.setTargetFunctionRole(
-      address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE),
+      address(LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE),
       Roles.getSpokeConfiguratorRoleSelectors(),
       Roles.SPOKE_CONFIGURATOR_ROLE
     );
@@ -184,16 +185,13 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   function test_mapleListings_before() public view virtual {
     uint256 usdcAssetId = GLOBAL_DOLLAR_HUB.getAssetId(AaveV4EthereumAssets.USDC_UNDERLYING);
     assertFalse(
-      GLOBAL_DOLLAR_HUB.isSpokeListed(
-        usdcAssetId,
-        address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)
-      ),
+      GLOBAL_DOLLAR_HUB.isSpokeListed(usdcAssetId, address(LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE)),
       'Maple Spoke should not have Global Dollar USDC before execution'
     );
 
     uint256 usdgAssetId = CORE_HUB.getAssetId(AaveV4EthereumAssets.USDG_UNDERLYING);
     assertFalse(
-      CORE_HUB.isSpokeListed(usdgAssetId, address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE)),
+      CORE_HUB.isSpokeListed(usdgAssetId, address(LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE)),
       'Maple Spoke should not have Core USDG before execution'
     );
   }
@@ -201,7 +199,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
   function test_mapleListings() public virtual {
     _executePayload();
 
-    address mapleSpoke = address(AaveV4EthereumRound12.USDG_MAPLE_ESPOKE);
+    address mapleSpoke = address(LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE);
     uint256 usdcAssetId = GLOBAL_DOLLAR_HUB.getAssetId(AaveV4EthereumAssets.USDC_UNDERLYING);
     assertTrue(
       GLOBAL_DOLLAR_HUB.isSpokeListed(usdcAssetId, mapleSpoke),
@@ -227,12 +225,12 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
 
   function _assertMapleReserve(IHub hub, address underlying) internal view {
     uint256 assetId = hub.getAssetId(underlying);
-    uint256 reserveId = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveId(address(hub), assetId);
-    ISpoke.Reserve memory reserve = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserve(reserveId);
-    ISpoke.ReserveConfig memory config = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE.getReserveConfig(
+    uint256 reserveId = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE.getReserveId(address(hub), assetId);
+    ISpoke.Reserve memory reserve = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE.getReserve(reserveId);
+    ISpoke.ReserveConfig memory config = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE.getReserveConfig(
       reserveId
     );
-    ISpoke.DynamicReserveConfig memory dynamicConfig = AaveV4EthereumRound12
+    ISpoke.DynamicReserveConfig memory dynamicConfig = LocalAaveV4Ethereum
       .USDG_MAPLE_ESPOKE
       .getDynamicReserveConfig(reserveId, reserve.dynamicConfigKey);
     assertEq(reserve.underlying, underlying, 'underlying mismatch');
@@ -276,7 +274,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
     for (uint256 i; i < currentSpokes.length; ++i) {
       spokes[i] = currentSpokes[i];
     }
-    spokes[currentSpokes.length] = AaveV4EthereumRound12.USDG_MAPLE_ESPOKE;
+    spokes[currentSpokes.length] = LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE;
     return spokes;
   }
 

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import {IHub, IAccessManagerEnumerable, ISpoke} from 'aave-address-book/AaveV4.sol';
 import {IExecutor} from 'aave-address-book/governance-v3/IExecutor.sol';
 import {AaveV4Ethereum, AaveV4EthereumHubs, AaveV4EthereumSpokes, AaveV4EthereumTokenizationSpokes, AaveV4EthereumAssets, AaveV4EthereumGetters} from 'aave-address-book/AaveV4Ethereum.sol';
-import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
 import {Roles} from 'aave-v4/deployments/utils/libraries/Roles.sol';
 import {Types} from 'aave-helpers/src/dependencies/v4/Types.sol';
 
@@ -32,15 +31,6 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_Test is ProtocolV4TestBase {
 
   function setUp() public virtual {
     vm.createSelectFork(vm.rpcUrl('mainnet'), 25673317);
-
-    // The Maple listing proposal performs this AccessManager setup through Governance before
-    // this Security Council payload is executed.
-    vm.prank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
-    ACCESS_MANAGER.setTargetFunctionRole(
-      address(LocalAaveV4Ethereum.USDG_MAPLE_ESPOKE),
-      Roles.getSpokeConfiguratorRoleSelectors(),
-      Roles.SPOKE_CONFIGURATOR_ROLE
-    );
 
     payload = new AaveV4Ethereum_IncreaseCaps_20260803();
   }

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803_Fork.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803_Fork.t.sol
@@ -24,9 +24,7 @@ contract AaveV4Ethereum_IncreaseCaps_20260803_ForkTest is
 
   function test_caps_primeHub_before() public view override {}
 
-  function test_caps_plusHub_before() public view override {}
-
-  function test_mapleCreditLine_before() public view override {}
+  function test_mapleListings_before() public view override {}
 
   function _executePayload() internal override {}
 }

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803_Fork.t.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803_Fork.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV4Ethereum_IncreaseCaps_20260803_Test} from './AaveV4Ethereum_IncreaseCaps_20260803.t.sol';
+
+/**
+ * @dev Fork test - forks from a block where the payload has already been executed.
+ * Verifies post-execution state: caps and e2e flows.
+ * Skipped when RPC_TENDERLY_VTESTNET is not set.
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260803_Multi_AaveV4CapsIncreaseRound12/AaveV4Ethereum_IncreaseCaps_20260803_Fork.t.sol -vv
+ */
+contract AaveV4Ethereum_IncreaseCaps_20260803_ForkTest is
+  AaveV4Ethereum_IncreaseCaps_20260803_Test
+{
+  function setUp() public override {
+    string memory rpcUrl = vm.envOr('RPC_TENDERLY_VTESTNET', string(''));
+    vm.skip(bytes(rpcUrl).length == 0);
+    vm.createSelectFork(rpcUrl);
+  }
+
+  function test_executeWithRecording() public override {}
+
+  function test_caps_coreHub_before() public view override {}
+
+  function test_caps_primeHub_before() public view override {}
+
+  function test_caps_plusHub_before() public view override {}
+
+  function test_mapleCreditLine_before() public view override {}
+
+  function _executePayload() internal override {}
+}

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
@@ -5,6 +5,10 @@ import {IAaveV4ConfigEngine} from 'aave-v4/config-engine/interfaces/IAaveV4Confi
 import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
 
 library LocalAaveV4Ethereum {
+  // https://etherscan.io/address/0xa1673fbD457747A05e91D9ef904Cb12827916B1E
+  IAaveV4ConfigEngine internal constant CONFIG_ENGINE =
+    IAaveV4ConfigEngine(0xa1673fbD457747A05e91D9ef904Cb12827916B1E);
+
   // Not available in the address book version pinned by feat/aave-v4.
   // https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989
   ISpoke internal constant USDG_MAPLE_ESPOKE = ISpoke(0x774b9655413c34809c1f1b16b654465A89EBE989);

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
@@ -4,7 +4,13 @@ pragma solidity ^0.8.0;
 import {IAaveV4ConfigEngine} from 'aave-v4/config-engine/interfaces/IAaveV4ConfigEngine.sol';
 import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
 
-library AaveV4AvalancheRound12 {
+library LocalAaveV4Ethereum {
+  // Not available in the address book version pinned by feat/aave-v4.
+  // https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989
+  ISpoke internal constant USDG_MAPLE_ESPOKE = ISpoke(0x774b9655413c34809c1f1b16b654465A89EBE989);
+}
+
+library LocalAaveV4Avalanche {
   // https://snowscan.xyz/address/0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c
   IAaveV4ConfigEngine internal constant CONFIG_ENGINE =
     IAaveV4ConfigEngine(0x1F0C67Fde7FcaF7eCEA43b76A23461803972c45c);

--- a/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
+++ b/src/20260803_Multi_AaveV4CapsIncreaseRound12/LocalV4AddressBook.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IAaveV4ConfigEngine} from 'aave-v4/config-engine/interfaces/IAaveV4ConfigEngine.sol';
-import {IHubConfigurator, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
+import {IHubConfigurator, ITokenizationSpoke, ISpoke, IHub} from 'aave-address-book/AaveV4.sol';
 
 library LocalAaveV4Ethereum {
   // https://etherscan.io/address/0xa1673fbD457747A05e91D9ef904Cb12827916B1E
@@ -12,6 +12,10 @@ library LocalAaveV4Ethereum {
   // Not available in the address book version pinned by feat/aave-v4.
   // https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989
   ISpoke internal constant USDG_MAPLE_ESPOKE = ISpoke(0x774b9655413c34809c1f1b16b654465A89EBE989);
+
+  // https://etherscan.io/address/0x378B4a7c394E22bd562F66eB612165893533c124
+  ITokenizationSpoke internal constant GLOBAL_DOLLAR_USDG_TOKENIZATION_SPOKE =
+    ITokenizationSpoke(0x378B4a7c394E22bd562F66eB612165893533c124);
 }
 
 library LocalAaveV4Avalanche {


### PR DESCRIPTION
Implements the twelfth Aave v4 cap increase round for Ethereum and Avalanche according to the [official LlamaRisk governance post](https://governance.aave.com/t/arfc-aave-v4-activation-on-ethereum-mainnet/24293/40).

- updates the requested caps across Ethereum Core and Prime, and Avalanche Core
- lists USDC on the Maple syrupUSDG spoke against the Global Dollar Hub with 1M add/draw caps and collateral disabled
- adds the 5M USDG draw-only credit line from Core to the Maple spoke
- includes deployment scripts, fork tests, the proposal specification, and generated state diffs
- keeps an inline Maple spoke constant because `feat/aave-v4` requires an `aave-helpers` revision whose pinned address book predates that constant